### PR TITLE
Add build token attribute to host resource

### DIFF
--- a/docs/resources/foreman_host.md
+++ b/docs/resources/foreman_host.md
@@ -75,4 +75,5 @@ The following attributes are exported:
 - `parameters` - A map of parameters that will be saved as host parameters in the machine config.
 - `puppet_class_ids` - IDs of the applied puppet classes.
 - `retry_count` - Number of times to retry on a failed attempt to register or delete a host in foreman.
+- `token` - Build token. Can be used to signal to Foreman that a host build is complete.
 

--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -93,6 +93,8 @@ type ForemanHost struct {
 	ComputeProfileId *int `json:"compute_profile_id,omitempty"`
 	// IDs of the puppet classes applied to the host
 	PuppetClassIds []int `json:"puppet_class_ids,omitempty"`
+	// Build token
+	Token string `json:"token,omitempty"`
 }
 
 // ForemanInterfacesAttribute representing a hosts defined network interfaces

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -551,6 +551,12 @@ func resourceForemanHost() *schema.Resource {
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
 
+			"token": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Build token. Can be used to signal to Foreman that a host build is complete.",
+			},
+
 			// -- Key Components --
 			"interfaces_attributes": &schema.Schema{
 				Type:        schema.TypeList,
@@ -718,6 +724,7 @@ func buildForemanHost(d *schema.ResourceData) *api.ForemanHost {
 	host.DomainName = d.Get("domain_name").(string)
 	host.Managed = d.Get("managed").(bool)
 	host.Build = d.Get("build").(bool)
+	host.Token = d.Get("token").(string)
 
 	ownerId := d.Get("owner_id").(int)
 	if ownerId != 0 {
@@ -941,6 +948,7 @@ func setResourceDataFromForemanHost(d *schema.ResourceData, fh *api.ForemanHost)
 	d.Set("image_id", fh.ImageId)
 	d.Set("model_id", fh.ModelId)
 	d.Set("puppet_class_ids", fh.PuppetClassIds)
+	d.Set("token", fh.Token)
 
 	setResourceDataFromForemanInterfacesAttributes(d, fh)
 }


### PR DESCRIPTION
Useful for signaling build completion, especially when Foreman is managing Puppet CA.