### PR TITLE
Convert subnet belongs_to IDs to pointers

### DIFF
--- a/foreman/api/subnet.go
+++ b/foreman/api/subnet.go
@@ -59,15 +59,15 @@ type ForemanSubnet struct {
 	// MTU Default for the subnet
 	Mtu int `json:"mtu"`
 	// Template ID
-	TemplateID int `json:"template_id,omitempty"`
+	TemplateID *int `json:"template_id"`
 	// DHCP ID
-	DhcpID int `json:"dhcp_id,omitempty"`
+	DhcpID *int `json:"dhcp_id"`
 	// BMC ID
-	BmcID *int `json:"bmc_id,omitempty"`
+	BmcID *int `json:"bmc_id"`
 	// TFTP ID
-	TftpID int `json:"tftp_id,omitempty"`
+	TftpID *int `json:"tftp_id"`
 	// HTTP Boot ID
-	HTTPBootID int `json:"httpboot_id,omitempty"`
+	HTTPBootID *int `json:"httpboot_id"`
 	// Domain IDs
 	DomainIDs []int `json:"domain_ids"`
 	// Domains (for internal use)

--- a/foreman/resource_foreman_subnet.go
+++ b/foreman/resource_foreman_subnet.go
@@ -17,7 +17,6 @@ import (
 
 func resourceForemanSubnet() *schema.Resource {
 	return &schema.Resource{
-
 		CreateContext: resourceForemanSubnetCreate,
 		ReadContext:   resourceForemanSubnetRead,
 		UpdateContext: resourceForemanSubnetUpdate,
@@ -28,7 +27,6 @@ func resourceForemanSubnet() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-
 			autodoc.MetaAttribute: {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -245,20 +243,24 @@ func buildForemanSubnet(d *schema.ResourceData) *api.ForemanSubnet {
 		s.Mtu = attr.(int)
 	}
 	if attr, ok = d.GetOk("template_id"); ok {
-		s.TemplateID = attr.(int)
+		templateID := attr.(int)
+		s.TemplateID = &templateID
 	}
 	if attr, ok = d.GetOk("dhcp_id"); ok {
-		s.DhcpID = attr.(int)
+		dhcpID := attr.(int)
+		s.DhcpID = &dhcpID
 	}
 	bmcId := d.Get("bmc_id").(int)
 	if bmcId != 0 {
 		s.BmcID = &bmcId
 	}
 	if attr, ok = d.GetOk("tftp_id"); ok {
-		s.TftpID = attr.(int)
+		tftpID := attr.(int)
+		s.TftpID = &tftpID
 	}
 	if attr, ok = d.GetOk("httpboot_id"); ok {
-		s.HTTPBootID = attr.(int)
+		httpBootID := attr.(int)
+		s.HTTPBootID = &httpBootID
 	}
 	if attr, ok = d.GetOk("domain_ids"); ok {
 		attrSet := attr.(*schema.Set)


### PR DESCRIPTION
Otherwise it is impossible to unset some links, such as removing the tftp link from a subnet.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>