### PR TITLE
Implement settings API as data source

### DIFF
--- a/examples/setting/main.tf
+++ b/examples/setting/main.tf
@@ -1,0 +1,35 @@
+variable "client_username" {}
+variable "client_password" {}
+
+provider "foreman" {
+  server_hostname = "192.168.1.118"
+  server_protocol = "https"
+
+  client_tls_insecure = true
+
+  client_username = "${var.client_username}"
+  client_password = "${var.client_password}"
+}
+
+# Read the data resource (it's read-only at the moment)
+data "foreman_setting" "append_domain" {
+	name = "append_domain_name_for_hosts"
+}
+
+# Then use e.g. data.foreman_setting.append_domain:
+output "setting_append_domain" {
+    value = data.foreman_setting.append_domain
+}
+
+# Result:
+# setting_append_domain = {
+#   __meta__      = null
+#   category_name = "General"
+#   default       = null
+#   description   = "Foreman will append domain names when new hosts are provisioned"
+#   id            = "append_domain_name_for_hosts"
+#   name          = "append_domain_name_for_hosts"
+#   readonly      = false
+#   settings_type = "boolean"
+#   value         = "true"
+# }

--- a/examples/setting/main.tf
+++ b/examples/setting/main.tf
@@ -13,7 +13,7 @@ provider "foreman" {
 
 # Read the data resource (it's read-only at the moment)
 data "foreman_setting" "append_domain" {
-	name = "append_domain_name_for_hosts"
+    name = "append_domain_name_for_hosts"
 }
 
 # Then use e.g. data.foreman_setting.append_domain:

--- a/foreman/api/setting.go
+++ b/foreman/api/setting.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/HanseMerkur/terraform-provider-utils/log"
+)
+
+const (
+	SettingEndpointPrefix = "settings"
+)
+
+// Represents a setting object in Foreman. Settings use strings as Id values.
+type ForemanSetting struct {
+	ForemanObject
+
+	// Settings use strings as IDs
+	// Overrides the ForemanObject.Id field
+	Id string `json:"id"`
+
+	// full_name field which seems to be empty
+	Fullname string `json:"full_name,omitempty"`
+
+	// The value of the setting, can be bool, string or int
+	Value interface{} `json:"value"`
+
+	// DO NOT USE: In case the value is a boolean, it could be stored in here
+	// Go does not allow setting this field to nil, which would be the correct
+	// value for Values that are strings. Unexpected behaviour - do not use!
+	// ValueBool bool
+
+	// Default value as bool, string or int
+	Default interface{} `json:"default"`
+
+	// Is setting read-only?
+	ReadOnly bool `json:"readonly"`
+
+	// Is setting encrypted?
+	Encrypted bool `json:"encrypted"`
+
+	// Description of the setting
+	Description string `json:"description"`
+
+	// Category of the setting in colon form, e.g. "Setting::Auth"
+	Category string `json:"category"`
+
+	// Category of the setting in human readable form, e.g. "Authentication"
+	CategoryName string `json:"category_name"`
+
+	// Type of the setting (boolean, string etc.)
+	SettingsType string `json:"settings_type,omitempty"`
+}
+
+// ReadSetting reads the attributes of a ForemanSetting identified by the supplied
+// ID and returns a ForemanSetting reference.
+func (c *Client) ReadSetting(ctx context.Context, id string) (*ForemanSetting, error) {
+	log.Tracef("foreman/api/setting.go#Read")
+
+	reqEndpoint := fmt.Sprintf("/%s/%s", SettingEndpointPrefix, id)
+
+	req, reqErr := c.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		reqEndpoint,
+		nil,
+	)
+	if reqErr != nil {
+		return nil, reqErr
+	}
+
+	var readSetting ForemanSetting
+	sendErr := c.SendAndParse(req, &readSetting)
+	if sendErr != nil {
+		return nil, sendErr
+	}
+
+	log.Debugf("readSetting: [%+v]", readSetting)
+
+	return &readSetting, nil
+}
+
+// QuerySetting queries for a ForemanSetting based on the attributes of the
+// supplied ForemanSetting reference and returns a QueryResponse struct
+// containing query/response metadata and the matching settings.
+// TODO: Copied from QueryDomains.
+func (c *Client) QuerySetting(ctx context.Context, d *ForemanSetting) (QueryResponse, error) {
+	log.Tracef("foreman/api/setting.go#Query")
+
+	queryResponse := QueryResponse{}
+
+	reqEndpoint := fmt.Sprintf("/%s", SettingEndpointPrefix)
+	req, reqErr := c.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		reqEndpoint,
+		nil,
+	)
+	if reqErr != nil {
+		return queryResponse, reqErr
+	}
+
+	// dynamically build the query based on the attributes
+	reqQuery := req.URL.Query()
+	name := `"` + d.Name + `"`
+	reqQuery.Set("search", "name="+name)
+
+	req.URL.RawQuery = reqQuery.Encode()
+	sendErr := c.SendAndParse(req, &queryResponse)
+	if sendErr != nil {
+		return queryResponse, sendErr
+	}
+
+	log.Debugf("queryResponse: [%+v]", queryResponse)
+
+	// Results will be Unmarshaled into a []map[string]interface{}
+	//
+	// Encode back to JSON, then Unmarshal into []ForemanSetting for
+	// the results
+	results := []ForemanSetting{}
+	resultsBytes, jsonEncErr := json.Marshal(queryResponse.Results)
+	if jsonEncErr != nil {
+		return queryResponse, jsonEncErr
+	}
+	jsonDecErr := json.Unmarshal(resultsBytes, &results)
+	if jsonDecErr != nil {
+		return queryResponse, jsonDecErr
+	}
+	// convert the search results from []ForemanSetting to []interface
+	// and set the search results on the query
+	iArr := make([]interface{}, len(results))
+	for idx, val := range results {
+		iArr[idx] = val
+	}
+	queryResponse.Results = iArr
+
+	return queryResponse, nil
+}

--- a/foreman/api/setting.go
+++ b/foreman/api/setting.go
@@ -51,7 +51,7 @@ type ForemanSetting struct {
 	CategoryName string `json:"category_name"`
 
 	// Type of the setting (boolean, string etc.)
-	SettingsType string `json:"settings_type,omitempty"`
+	SettingsType string `json:"settings_type"`
 }
 
 // ReadSetting reads the attributes of a ForemanSetting identified by the supplied

--- a/foreman/data_source_foreman_setting.go
+++ b/foreman/data_source_foreman_setting.go
@@ -97,6 +97,8 @@ func dataSourceForemanSettingRead(ctx context.Context, d *schema.ResourceData, m
 	obj := buildForemanObject(d)
 	setting.ForemanObject = *obj
 
+	setting.Id = d.Id()
+
 	log.Debugf("ForemanSetting: [%+v]", setting)
 
 	queryResponse, queryErr := client.QuerySetting(ctx, setting)
@@ -129,6 +131,17 @@ func dataSourceForemanSettingRead(ctx context.Context, d *schema.ResourceData, m
 		setting.Value = strconv.FormatBool(setting.Value.(bool))
 	case int:
 		setting.Value = strconv.FormatInt(setting.Value.(int64), 10)
+	case string:
+	default:
+		// noop
+	}
+
+	// Same for the default value
+	switch setting.Default.(type) {
+	case bool:
+		setting.Default = strconv.FormatBool(setting.Default.(bool))
+	case int:
+		setting.Default = strconv.FormatInt(setting.Default.(int64), 10)
 	case string:
 	default:
 		// noop

--- a/foreman/data_source_foreman_setting.go
+++ b/foreman/data_source_foreman_setting.go
@@ -1,0 +1,150 @@
+package foreman
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/HanseMerkur/terraform-provider-utils/autodoc"
+	"github.com/HanseMerkur/terraform-provider-utils/log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/api"
+)
+
+func dataSourceForemanSetting() *schema.Resource {
+	// Build schema from scratch, because Setting is a data source only.
+	// There is no resource schema we could re-use.
+
+	dataSourceSchema := map[string]*schema.Schema{
+
+		autodoc.MetaAttribute: {
+			Type:     schema.TypeBool,
+			Computed: true,
+			Description: fmt.Sprintf(
+				"%s Setting can be used to read settings from Foreman.",
+				autodoc.MetaSummary,
+			),
+		},
+
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			Description: fmt.Sprintf(
+				"Name of the setting"+
+					"%s \"foreman_url\"",
+				autodoc.MetaExample,
+			),
+		},
+
+		// Value can be either string, int or bool.
+		// The API client converts int and bool to string..
+		"value": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Description: fmt.Sprintf(
+				"Value of the setting"+
+					"%s \"https://foreman.company.com\"",
+				autodoc.MetaExample,
+			),
+		},
+
+		"default": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Default value of the setting",
+		},
+
+		"readonly": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether the setting is read-only or not.",
+		},
+
+		"description": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Description of the setting",
+		},
+
+		"category_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Name of the category the setting is in.",
+		},
+	}
+
+	return &schema.Resource{
+		ReadContext: dataSourceForemanSettingRead,
+		Schema:      dataSourceSchema,
+	}
+}
+
+func dataSourceForemanSettingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Tracef("data_source_foreman_setting.go#Read")
+
+	var diags diag.Diagnostics
+
+	client := meta.(*api.Client)
+	setting := &api.ForemanSetting{}
+
+	// Build basic Foreman object inside struct
+	obj := buildForemanObject(d)
+	setting.ForemanObject = *obj
+
+	log.Debugf("ForemanSetting: [%+v]", setting)
+
+	queryResponse, queryErr := client.QuerySetting(ctx, setting)
+	if queryErr != nil {
+		return diag.FromErr(queryErr)
+	}
+
+	if queryResponse.Subtotal == 0 {
+		return diag.Errorf("Data source setting returned no results")
+	} else if queryResponse.Subtotal > 1 {
+		return diag.Errorf("Data source setting returned more than 1 result")
+	}
+
+	var querySetting api.ForemanSetting
+	var ok bool
+	if querySetting, ok = queryResponse.Results[0].(api.ForemanSetting); !ok {
+		return diag.Errorf(
+			"Data source results contain unexpected type. Expected "+
+				"[api.ForemanSetting], got [%T]",
+			queryResponse.Results[0],
+		)
+	}
+	setting = &querySetting
+
+	// Convert boolean or integer values to strings to match the schema
+	switch setting.Value.(type) {
+	case bool:
+		setting.Value = strconv.FormatBool(setting.Value.(bool))
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("The value for setting %s was a boolean and was converted to string", setting.Name),
+		})
+	case int:
+		setting.Value = strconv.FormatInt(setting.Value.(int64), 10)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("The value for setting %s was an integer and was converted to string", setting.Name),
+		})
+	case string:
+	default:
+		// noop
+	}
+
+	log.Debugf("ForemanSetting: [%+v]", setting)
+
+	d.SetId(setting.Id)
+	d.Set("name", setting.Name)
+	d.Set("value", setting.Value)
+	d.Set("description", setting.Description)
+	d.Set("default", setting.Default)
+	d.Set("category_name", setting.CategoryName)
+	d.Set("readonly", setting.ReadOnly)
+
+	return diags
+}

--- a/foreman/data_source_foreman_setting.go
+++ b/foreman/data_source_foreman_setting.go
@@ -73,6 +73,12 @@ func dataSourceForemanSetting() *schema.Resource {
 			Computed:    true,
 			Description: "Name of the category the setting is in.",
 		},
+
+		"settings_type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Data type of this setting (boolean, string, ..)",
+		},
 	}
 
 	return &schema.Resource{
@@ -145,6 +151,7 @@ func dataSourceForemanSettingRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("default", setting.Default)
 	d.Set("category_name", setting.CategoryName)
 	d.Set("readonly", setting.ReadOnly)
+	d.Set("settings_type", setting.SettingsType)
 
 	return diags
 }

--- a/foreman/data_source_foreman_setting_test.go
+++ b/foreman/data_source_foreman_setting_test.go
@@ -1,0 +1,115 @@
+package foreman
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/api"
+)
+
+func RandForemanSetting() api.ForemanSetting {
+	obj := api.ForemanSetting{}
+
+	fo := RandForemanObject()
+	obj.ForemanObject = fo
+
+	// Settings API uses string as Id, overridden
+	obj.Id = fmt.Sprintf("randomSetting%d", fo.Id)
+
+	return obj
+}
+
+func ForemanSettingToInstanceState(obj api.ForemanSetting) *terraform.InstanceState {
+	state := terraform.InstanceState{}
+	state.ID = obj.Id
+
+	attr := map[string]string{}
+	attr["id"] = obj.Id
+	attr["name"] = obj.Name
+
+	if obj.Default != nil {
+		attr["default"] = obj.Default.(string)
+	}
+
+	attr["description"] = obj.Description
+	attr["settings_type"] = obj.SettingsType
+	attr["created_at"] = obj.CreatedAt
+	attr["updated_at"] = obj.UpdatedAt
+	attr["full_name"] = obj.Fullname
+
+	if obj.Value != nil {
+		attr["value"] = obj.Value.(string)
+	}
+
+	attr["category"] = obj.Category
+	attr["category_name"] = obj.CategoryName
+
+	state.Attributes = attr
+	return &state
+}
+
+// ----------------------------------------------------------------------------
+// Test Cases for the Unit Test Framework
+// ----------------------------------------------------------------------------
+
+func DataSourceForemanSettingMockResponseTestCases(t *testing.T) []TestCaseMockResponse {
+
+	obj := RandForemanSetting()
+	s := ForemanSettingToInstanceState(obj)
+
+	return []TestCaseMockResponse{
+		{
+			TestCase: TestCase{
+				funcName:     "dataSourceForemanSettingRead",
+				crudFunc:     dataSourceForemanSettingRead,
+				resourceData: MockForemanSettingResourceData(s),
+			},
+			responseFile: TestDataPath + "/settings/query_response_single.json",
+			returnError:  false,
+			expectedResourceData: MockForemanSettingResourceDataFromFile(
+				t,
+				TestDataPath+"/settings/query_response_single_state.json",
+			),
+			compareFunc: ForemanSettingResourceDataCompare,
+		},
+	}
+}
+
+func MockForemanSettingResourceData(s *terraform.InstanceState) *schema.ResourceData {
+	r := dataSourceForemanSetting()
+	return r.Data(s)
+}
+
+// Reads the JSON for the file at the path and creates a  domain
+// ResourceData reference
+func MockForemanSettingResourceDataFromFile(t *testing.T, path string) *schema.ResourceData {
+	var obj api.ForemanSetting
+	ParseJSONFile(t, path, &obj)
+	s := ForemanSettingToInstanceState(obj)
+	return MockForemanSettingResourceData(s)
+}
+
+func ForemanSettingResourceDataCompare(t *testing.T, r1 *schema.ResourceData, r2 *schema.ResourceData) {
+
+	// compare IDs
+	if r1.Id() != r2.Id() {
+		t.Fatalf(
+			"ResourceData references differ in Id. [%s], [%s]",
+			r1.Id(),
+			r2.Id(),
+		)
+	}
+
+	// build the attribute map
+	m := map[string]schema.ValueType{}
+	r := dataSourceForemanSetting()
+	for key, value := range r.Schema {
+		m[key] = value.Type
+	}
+
+	// compare the rest of the attributes
+	CompareResourceDataAttributes(t, m, r1, r2)
+
+}

--- a/foreman/foreman_api_test.go
+++ b/foreman/foreman_api_test.go
@@ -668,6 +668,8 @@ func TestCRUDFunction_MockResponse(t *testing.T) {
 
 	testCases = append(testCases, DataSourceForemanPuppetClassMockResponseTestCases(t)...)
 
+	testCases = append(testCases, DataSourceForemanSettingMockResponseTestCases(t)...)
+
 	testCases = append(testCases, DataSourceForemanSmartClassParameterMockResponseTestCases(t)...)
 
 	testCases = append(testCases, ResourceForemanSmartProxyMockResponseTestCases(t)...)

--- a/foreman/provider.go
+++ b/foreman/provider.go
@@ -231,6 +231,7 @@ func Provider() *schema.Provider {
 			"foreman_katello_sync_plan":          dataSourceForemanKatelloSyncPlan(),
 			"foreman_user":                       dataSourceForemanUser(),
 			"foreman_usergroup":                  dataSourceForemanUsergroup(),
+			"foreman_setting":                    dataSourceForemanSetting(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -1053,24 +1053,6 @@ func resourceForemanHostCreate(ctx context.Context, d *schema.ResourceData, meta
 	// the "append_domain_name_for_hosts" setting. In case of true, a shortname will be expanded to
 	// a FQDN, resulting in inconsistent plans. Maybe this issue will arise again, then handle it here.
 
-	// Check the Foreman-internal setting for appending domains to host names.
-	// If enabled, passing in a short hostname will result in a different name as return value.
-	// Example: Setting is on, name = "mymachine" -> return value is "mymachine.domain.com"
-	// append_domains, err := client.ReadSetting(ctx, "append_domain_name_for_hosts")
-	// if err != nil {
-	// 	return diag.FromErr(err)
-	// }
-	// log.Debugf("append_domain_name_for_hosts: %+v", append_domains.Value)
-
-	// if append_domains.Value == true && h.DomainName != "" && !strings.Contains(h.Name, h.DomainName) {
-	// 	diag := diag.Diagnostic{
-	// 		Severity: diag.Warning,
-	// 		Summary:  "Hostname does not contain domain.",
-	// 		Detail:   fmt.Sprintf("The name %q does not contain the domain. Is it an FQDN? ", h.Name),
-	// 	}
-	// 	diags = append(diags, diag)
-	// }
-
 	log.Debugf("ForemanHost: [%+v]", h)
 	hostRetryCount := d.Get("retry_count").(int)
 

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -1049,23 +1049,27 @@ func resourceForemanHostCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	managed := d.Get("managed").(bool)
 
+	// Here, commit 7dad08886079b82672eee33f9e1247c5ca60bb77 used a query against the settings API to check
+	// the "append_domain_name_for_hosts" setting. In case of true, a shortname will be expanded to
+	// a FQDN, resulting in inconsistent plans. Maybe this issue will arise again, then handle it here.
+
 	// Check the Foreman-internal setting for appending domains to host names.
 	// If enabled, passing in a short hostname will result in a different name as return value.
 	// Example: Setting is on, name = "mymachine" -> return value is "mymachine.domain.com"
-	append_domains, err := client.ReadSetting(ctx, "append_domain_name_for_hosts")
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	log.Debugf("append_domain_name_for_hosts: %+v", append_domains.Value)
+	// append_domains, err := client.ReadSetting(ctx, "append_domain_name_for_hosts")
+	// if err != nil {
+	// 	return diag.FromErr(err)
+	// }
+	// log.Debugf("append_domain_name_for_hosts: %+v", append_domains.Value)
 
-	if append_domains.Value == true && h.DomainName != "" && !strings.Contains(h.Name, h.DomainName) {
-		diag := diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "Hostname does not contain domain.",
-			Detail:   fmt.Sprintf("The name %q does not contain the domain. Is it an FQDN? ", h.Name),
-		}
-		diags = append(diags, diag)
-	}
+	// if append_domains.Value == true && h.DomainName != "" && !strings.Contains(h.Name, h.DomainName) {
+	// 	diag := diag.Diagnostic{
+	// 		Severity: diag.Warning,
+	// 		Summary:  "Hostname does not contain domain.",
+	// 		Detail:   fmt.Sprintf("The name %q does not contain the domain. Is it an FQDN? ", h.Name),
+	// 	}
+	// 	diags = append(diags, diag)
+	// }
 
 	log.Debugf("ForemanHost: [%+v]", h)
 	hostRetryCount := d.Get("retry_count").(int)

--- a/foreman/resource_helper.go
+++ b/foreman/resource_helper.go
@@ -20,6 +20,8 @@ func buildForemanObject(d *schema.ResourceData) *api.ForemanObject {
 		obj.Id = 0
 	}
 
+	// TODO: settings API returns strings as IDs, but the core.go ForemanObject.Id is int
+
 	var attr interface{}
 	var ok bool
 

--- a/foreman/resource_helper.go
+++ b/foreman/resource_helper.go
@@ -20,8 +20,6 @@ func buildForemanObject(d *schema.ResourceData) *api.ForemanObject {
 		obj.Id = 0
 	}
 
-	// TODO: settings API returns strings as IDs, but the core.go ForemanObject.Id is int
-
 	var attr interface{}
 	var ok bool
 

--- a/foreman/testdata/1.11/settings/query_response_single.json
+++ b/foreman/testdata/1.11/settings/query_response_single.json
@@ -1,0 +1,30 @@
+{
+    "total": 6250,
+    "subtotal": 1,
+    "page": 1,
+    "per_page": 100,
+    "search": "test",
+    "sort": {
+      "by": null,
+      "order": null
+    },
+    "results": [
+        {
+            "description": "Foreman will append domain names when new hosts are provisioned",
+            "settings_type": "boolean",
+            "default": true,
+            "created_at": "2016-08-29 13:57:13 UTC",
+            "updated_at": "2018-05-22 19:03:29 UTC",
+            "id": "append_domain_name_for_hosts",
+            "name": "append_domain_name_for_hosts",
+            "full_name": "Append domain names to the host",
+            "value": true,
+            "category": "general",
+            "category_name": "General",
+            "readonly": false,
+            "config_file": null,
+            "encrypted": false,
+            "select_values": null
+        }
+    ]
+}

--- a/foreman/testdata/1.11/settings/query_response_single_state.json
+++ b/foreman/testdata/1.11/settings/query_response_single_state.json
@@ -1,0 +1,13 @@
+{
+    "description": "Foreman will append domain names when new hosts are provisioned",
+    "settings_type": "boolean",
+    "default": "true",
+    "created_at": "2016-08-29 13:57:13 UTC",
+    "updated_at": "2018-05-22 19:03:29 UTC",
+    "id": "append_domain_name_for_hosts",
+    "name": "append_domain_name_for_hosts",
+    "full_name": "Append domain names to the host",
+    "value": "true",
+    "category": "general",
+    "category_name": "General"
+}


### PR DESCRIPTION
Implements the API calls for ReadSetting and QuerySetting, allowing a read-only usage of the Foreman settings API.

As an example, the setting "append_domain_name_for_hosts" is read in the resourceForemanHostCreate func to handle the issue with short names and FQDNs as return value.

Refs #116