### PR TITLE
Add more fields to Foreman host 

### DIFF
--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -68,6 +68,7 @@ type ForemanHost struct {
 	ArchitectureId *int `json:"architecture_id,omitempty"`
 	// Name of the architecture of this host
 	// ArchitectureName string `json:"architecture_name,omitempty"`
+	SubnetId *int `json:"subnet_id,omitempty"`
 	// ID of the operating system to put on the host
 	OperatingSystemId *int `json:"operatingsystem_id,omitempty"`
 	// ID of the medium that should be mounted
@@ -76,6 +77,8 @@ type ForemanHost struct {
 	ImageId *int `json:"image_id,omitempty"`
 	// ID of the hardware model
 	ModelId *int `json:"model_id,omitempty"`
+	// Ptables ID
+	PtableId *int `json:"ptable_id,omitempty"`
 	// Whether or not to Enable BMC Functionality on this host
 	EnableBMC bool `json:"-"`
 	// Boolean to track success of BMC Calls
@@ -103,6 +106,8 @@ type ForemanHost struct {
 	ConfigGroupIds []int `json:"config_group_ids"`
 	// The puppetattributes object is only used for create and update, it's not populated on read, hence the duplication
 	PuppetAttributes PuppetAttribute `json:"puppet_attributes"`
+	// Default Root Password for this host (on creation)
+	RootPassword string `json:"root_pass,omitempty"`
 }
 
 // ForemanInterfacesAttribute representing a hosts defined network interfaces

--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -64,6 +64,10 @@ type ForemanHost struct {
 	EnvironmentId *int `json:"environment_id,omitempty"`
 	// ID of the hostgroup to assign the host
 	HostgroupId *int `json:"hostgroup_id,omitempty"`
+	// ID of the architecture of this host
+	ArchitectureId *int `json:"architecture_id,omitempty"`
+	// Name of the architecture of this host
+	// ArchitectureName string `json:"architecture_name,omitempty"`
 	// ID of the operating system to put on the host
 	OperatingSystemId *int `json:"operatingsystem_id,omitempty"`
 	// ID of the medium that should be mounted

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -344,6 +344,14 @@ func resourceForemanHost() *schema.Resource {
 
 			// -- Optional --
 
+			"root_password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringLenBetween(8, 256),
+				Description:  "Default root password",
+			},
+
 			"method": {
 				Type:       schema.TypeString,
 				Optional:   true,
@@ -486,6 +494,22 @@ func resourceForemanHost() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description:  "ID of the architecture of this host",
+			},
+
+			"subnet_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "ID of the subnet the host should be placed in",
+			},
+
+			"ptable_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "ID of the partition table the host should use",
 			},
 
 			"operatingsystem_id": {
@@ -765,6 +789,14 @@ func buildForemanHost(d *schema.ResourceData) *api.ForemanHost {
 	if architectureId != 0 {
 		host.ArchitectureId = &architectureId
 	}
+	subnetId := d.Get("subnet_id").(int)
+	if subnetId != 0 {
+		host.SubnetId = &subnetId
+	}
+	ptableId := d.Get("ptable_id").(int)
+	if ptableId != 0 {
+		host.PtableId = &ptableId
+	}
 	operatingSystemId := d.Get("operatingsystem_id").(int)
 	if operatingSystemId != 0 {
 		host.OperatingSystemId = &operatingSystemId
@@ -808,6 +840,10 @@ func buildForemanHost(d *schema.ResourceData) *api.ForemanHost {
 
 	if attr, ok = d.GetOk("parameters"); ok {
 		host.HostParameters = api.ToKV(attr.(map[string]interface{}))
+	}
+
+	if attr, ok = d.GetOk("root_password"); ok {
+		host.RootPassword = attr.(string)
 	}
 
 	host.InterfacesAttributes = buildForemanInterfacesAttributes(d)
@@ -973,6 +1009,8 @@ func setResourceDataFromForemanHost(d *schema.ResourceData, fh *api.ForemanHost)
 	d.Set("owner_type", fh.OwnerType)
 	d.Set("hostgroup_id", fh.HostgroupId)
 	d.Set("architecture_id", fh.ArchitectureId)
+	d.Set("ptable_id", fh.PtableId)
+	d.Set("subnet_id", fh.SubnetId)
 	d.Set("compute_resource_id", fh.ComputeResourceId)
 	d.Set("compute_profile_id", fh.ComputeProfileId)
 	d.Set("operatingsystem_id", fh.OperatingSystemId)

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -479,6 +479,15 @@ func resourceForemanHost() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(0),
 				Description:  "ID of the environment to assign to the host.",
 			},
+
+			"architecture_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "ID of the architecture of this host",
+			},
+
 			"operatingsystem_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -752,6 +761,10 @@ func buildForemanHost(d *schema.ResourceData) *api.ForemanHost {
 	if hostgroupId != 0 {
 		host.HostgroupId = &hostgroupId
 	}
+	architectureId := d.Get("architecture_id").(int)
+	if architectureId != 0 {
+		host.ArchitectureId = &architectureId
+	}
 	operatingSystemId := d.Get("operatingsystem_id").(int)
 	if operatingSystemId != 0 {
 		host.OperatingSystemId = &operatingSystemId
@@ -959,6 +972,7 @@ func setResourceDataFromForemanHost(d *schema.ResourceData, fh *api.ForemanHost)
 	d.Set("owner_id", fh.OwnerId)
 	d.Set("owner_type", fh.OwnerType)
 	d.Set("hostgroup_id", fh.HostgroupId)
+	d.Set("architecture_id", fh.ArchitectureId)
 	d.Set("compute_resource_id", fh.ComputeResourceId)
 	d.Set("compute_profile_id", fh.ComputeProfileId)
 	d.Set("operatingsystem_id", fh.OperatingSystemId)

--- a/foreman/resource_foreman_host_test.go
+++ b/foreman/resource_foreman_host_test.go
@@ -45,6 +45,12 @@ func ForemanHostToInstanceState(obj api.ForemanHost) *terraform.InstanceState {
 	if obj.HostgroupId != nil {
 		attr["hostgroup_id"] = strconv.Itoa(*obj.HostgroupId)
 	}
+	if obj.ArchitectureId != nil {
+		attr["architecture_id"] = strconv.Itoa(*obj.ArchitectureId)
+	}
+	if obj.SubnetId != nil {
+		attr["subnet_id"] = strconv.Itoa(*obj.SubnetId)
+	}
 	if obj.OperatingSystemId != nil {
 		attr["operatingsystem_id"] = strconv.Itoa(*obj.OperatingSystemId)
 	}
@@ -59,6 +65,9 @@ func ForemanHostToInstanceState(obj api.ForemanHost) *terraform.InstanceState {
 	}
 	if obj.ModelId != nil {
 		attr["owner_id"] = strconv.Itoa(*obj.ModelId)
+	}
+	if obj.PtableId != nil {
+		attr["ptable_id"] = strconv.Itoa(*obj.PtableId)
 	}
 	attr["owner_type"] = obj.OwnerType
 	attr["interfaces_attributes.#"] = strconv.Itoa(len(obj.InterfacesAttributes))


### PR DESCRIPTION
On this branch, more fields are supported by the Terraform provider in the Foreman host context. This enables the usage of foreman_host without the need to use a foreman_hostgroup to supply missing values.

- architecture_id: ID of the architecture to be used when creating the host
- subnet_id: ID of the subnet that should be used to gather an IP address for this host
- ptable_id: ID of the partitioning table