### PR TITLE
Add compatibility to "name" argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Terraform provider to interact with [Foreman](https://www.theforeman.org/).
 
+
+## Breaking changes in 0.6.x
+Starting with `v0.6.0` some breaking changes require an update of Terraform manifests.
+
+* The host `build` argument was removed (`0.6.0`) and is replaced by `set_build_flag`. (`0.6.1`)
+* The host `name` argument is deprecated (`0.6.1`). Please use `shortname` for your hostname instead. The `name` attribute has issues based on the "append_domain_name" setting in Foreman. We therefore bypass using the name directly and provide the argument `shortname` and the additional attribute `fqdn`. (`0.6.1`)
+
 ## Migration notice
 
 The provider has moved from its previous location at https://github.com/terraform-coop/terraform-provider-foreman

--- a/README.md
+++ b/README.md
@@ -3,11 +3,20 @@
 Terraform provider to interact with [Foreman](https://www.theforeman.org/).
 
 
-## Breaking changes in 0.6.x
-Starting with `v0.6.0` some breaking changes require an update of Terraform manifests.
+## Changes in 0.6.x
+Starting with `v0.6.0` some (breaking) changes require an update of Terraform manifests.
 
 * The host `build` argument was removed (`0.6.0`) and is replaced by `set_build_flag`. (`0.6.1`)
-* The host `name` argument is deprecated (`0.6.1`). Please use `shortname` for your hostname instead. The `name` attribute has issues based on the "append_domain_name" setting in Foreman. We therefore bypass using the name directly and provide the argument `shortname` and the additional attribute `fqdn`. (`0.6.1`)
+  * The reason behind this change is complex and was thoroughly discussed in https://github.com/terraform-coop/terraform-provider-foreman/discussions/125
+  * Using the argument does one thing: it tells Foreman to set the `build` flag for a host. It defaults to `false`, setting it to `true` causes the host to be re-installed on next boot (network-based installation).
+* The `method` argument is re-introduced as `provision_method`. It can be either `build` (network-based) or `image` (image-based).
+  * Both options require different additional arguments, e.g the image to be used. See `examples/host/`.
+* The host `name` argument was considered for deprecation (`0.6.0`). 
+  * The `name` attribute has issues based on the "append_domain_name" setting in Foreman. It causes "inconsistent plan" errors when you give it a shortname as value, Terraform receives an FQDN back, and the `name` attribute is then used in variables in other places in your Terraform manifests.
+  * As an alternative, the `shortname` argument can be used instead. It is meant for the hostname without the domain part. If you use `name` as input argument, `shortname` will be filled by the provider automatically.
+  * To get the host's FQDN from the provider, use the read-only attribute `fqdn`. (`0.6.1`)
+  * **Use `shortname` and `fqdn` as variables in your manifests**! Example: `other_server = foreman_host.other_server.fqdn`. This will prevent you from running into inconsistent plans.
+
 
 ## Migration notice
 

--- a/docs/resources/foreman_host.md
+++ b/docs/resources/foreman_host.md
@@ -18,6 +18,7 @@ resource "foreman_host" "example" {
 
 The following arguments are supported:
 
+- `architecture_id` - (Optional) ID of the architecture of this host
 - `bmc_success` - (Optional) REMOVED - Tracks the partial state of BMC operations on host creation. If these operations fail, the host will be created in Foreman and this boolean will remain `false`. On the next `terraform apply` will trigger the host update to pick back up with the BMC operations.
 - `comment` - (Optional) Add additional information about this host.Note: Changes to this attribute will trigger a host rebuild.
 - `compute_attributes` - (Optional) Hypervisor specific VM options. Must be a JSON string, as every compute provider has different attributes schema
@@ -34,21 +35,26 @@ The following arguments are supported:
 - `managed` - (Optional) Whether or not this host is managed by Foreman. Create host only, don't set build status or manage power states.
 - `medium_id` - (Optional, Force New) ID of the medium mounted on the host.
 - `model_id` - (Optional) ID of the hardware model if applicable
+- `name` - (Optional, Force New) Name of this host as stored in Foreman. Can be short name or FQDN, depending on your Foreman settings (especially the setting 'append_domain_name_for_hosts').
 - `operatingsystem_id` - (Optional, Force New) ID of the operating system to put on the host.
 - `owner_id` - (Optional) ID of the user or usergroup that owns the host.
 - `owner_type` - (Optional) Owner of the host, must be either User ot Usergroup
 - `parameters` - (Optional) A map of parameters that will be saved as host parameters in the machine config.
 - `provision_method` - (Optional, Force New) Sets the provision method in Foreman for this host: either network-based ('build') or image-based ('image')
+- `ptable_id` - (Optional) ID of the partition table the host should use
 - `puppet_class_ids` - (Optional) IDs of the applied puppet classes.
 - `retry_count` - (Optional) Number of times to retry on a failed attempt to register or delete a host in foreman.
+- `root_password` - (Optional) Default root password
 - `set_build_flag` - (Optional) Sets the Foreman-internal 'build' flag on this host - even if it is already built completely.
-- `shortname` - (Required, Force New) The short name of this host. Example: when the FQDN is 'host01.example.org', then 'host01' is the short name.
+- `shortname` - (Optional, Force New) The short name of this host. Example: when the FQDN is 'host01.example.org', then 'host01' is the short name.
+- `subnet_id` - (Optional) ID of the subnet the host should be placed in
 
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+- `architecture_id` - ID of the architecture of this host
 - `comment` - Add additional information about this host.Note: Changes to this attribute will trigger a host rebuild.
 - `compute_attributes` - Hypervisor specific VM options. Must be a JSON string, as every compute provider has different attributes schema
 - `compute_profile_id` - 
@@ -72,9 +78,12 @@ The following attributes are exported:
 - `owner_type` - Owner of the host, must be either User ot Usergroup
 - `parameters` - A map of parameters that will be saved as host parameters in the machine config.
 - `provision_method` - Sets the provision method in Foreman for this host: either network-based ('build') or image-based ('image')
+- `ptable_id` - ID of the partition table the host should use
 - `puppet_class_ids` - IDs of the applied puppet classes.
 - `retry_count` - Number of times to retry on a failed attempt to register or delete a host in foreman.
+- `root_password` - Default root password
 - `set_build_flag` - Sets the Foreman-internal 'build' flag on this host - even if it is already built completely.
 - `shortname` - The short name of this host. Example: when the FQDN is 'host01.example.org', then 'host01' is the short name.
+- `subnet_id` - ID of the subnet the host should be placed in
 - `token` - Build token. Can be used to signal to Foreman that a host build is complete.
 

--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -51,7 +51,7 @@ type ForemanHost struct {
 
 	// Shortname, FQDN without DomainName.
 	// Not provided by the API, only available in templates with embedded Ruby
-	Shortname string
+	Shortname string `json:"-"`
 
 	// The "fqdn" field in the Terraform schema exists only in the schema,
 	// not in this struct. Reason: name is a Foreman-managed field that can either hold

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -334,7 +334,6 @@ func resourceForemanHost() *schema.Resource {
 				Optional:         true,
 				ForceNew:         true,
 				Required:         false,
-				Deprecated:       "Deprecated. Use 'shortname' instead! Will be read-only in future versions.",
 				Description:      "Name of this host as stored in Foreman. Can be short name or FQDN, depending on your Foreman settings (especially the setting 'append_domain_name_for_hosts').",
 				DiffSuppressFunc: resourceForemanHostNameDiffSuppressFunc,
 			},
@@ -342,7 +341,7 @@ func resourceForemanHost() *schema.Resource {
 			"shortname": {
 				Type:        schema.TypeString,
 				ForceNew:    true,
-				Computed:    false,
+				Computed:    true,
 				Optional:    true,
 				Required:    false,
 				Description: "The short name of this host. Example: when the FQDN is 'host01.example.org', then 'host01' is the short name.",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
     - 'foreman_partitiontable': 'data-sources/foreman_partitiontable.md'
     - 'foreman_provisioningtemplate': 'data-sources/foreman_provisioningtemplate.md'
     - 'foreman_puppetclass': 'data-sources/foreman_puppetclass.md'
+    - 'foreman_setting': 'data-sources/foreman_setting.md'
     - 'foreman_smartclassparameter': 'data-sources/foreman_smartclassparameter.md'
     - 'foreman_smartproxy': 'data-sources/foreman_smartproxy.md'
     - 'foreman_subnet': 'data-sources/foreman_subnet.md'


### PR DESCRIPTION
The breaking change of making host.name read-only renders a lot of TF configs unusable. This commit adds diff suppression handling to work with name, shortname and fqdn even with older manifests.