### PR TITLE
Foreman image: implement, fix and improve usage

### DIFF
--- a/foreman/api/image.go
+++ b/foreman/api/image.go
@@ -127,7 +127,7 @@ func (c *Client) ReadImage(ctx context.Context, d *ForemanImage) (*ForemanImage,
 	return &readImage, nil
 }
 
-// UpdateImage updates a ForemanImage's attributes.  The image with the ID
+// UpdateImage updates a ForemanImage's attributes. The image with the ID
 // of the supplied ForemanImage will be updated. A new ForemanImage reference
 // is returned with the attributes from the result of the update operation.
 func (c *Client) UpdateImage(ctx context.Context, d *ForemanImage) (*ForemanImage, error) {

--- a/foreman/api/image.go
+++ b/foreman/api/image.go
@@ -61,10 +61,14 @@ func (c *Client) CreateImage(ctx context.Context, d *ForemanImage, compute_resou
 		"uuid": "%s",
 		"username": "%s",
 		"name": "%s",
-		"operatingsystem_id": "%d",
-		"architecture_id": "%d",
-		"compute_resource_id": "%d"
-	}}`, d.UUID, d.Username, d.Name, d.OperatingSystemID, d.ArchitectureID, d.ComputeResourceID))
+		"operatingsystem_id": %d,
+		"architecture_id": %d,
+		"compute_resource_id": %d,
+		"user_data": %t
+	}}`,
+		d.UUID, d.Username, d.Name,
+		d.OperatingSystemID, d.ArchitectureID, d.ComputeResourceID,
+		d.UserData))
 
 	log.Debugf("marsh: %s", marsh)
 

--- a/foreman/api/image.go
+++ b/foreman/api/image.go
@@ -23,25 +23,22 @@ const (
 // a portion of a network.
 
 type ForemanImage struct {
-	// Inherits the base object's attributes
 	ForemanObject
 
 	// UUID of the image. Can be the path to the image on the compute resource e.g.
 	UUID string `json:"uuid"`
 	// Username used for login on the image
 	Username string `json:"username"`
-	// Name of the image on the compute resource
-	Name string `json:"name"`
-
+	// Password for the initial user
+	Password string `json:"password"`
 	// OperatingSystemId of the operating system associated with the image
 	OperatingSystemID int `json:"operatingsystem_id"`
 	// ComputeResourceId of the resource this image can be cloned on
 	ComputeResourceID int `json:"compute_resource_id"`
 	// ArchitectureId of the architecture this image works on
 	ArchitectureID int `json:"architecture_id"`
-
-	UserData bool   `json:"user_data"`
-	Password string `json:"password"`
+	// Does the image support providing user data (e.g. cloud-init)?
+	UserData bool `json:"user_data"`
 }
 
 // -----------------------------------------------------------------------------

--- a/foreman/resource_foreman_image.go
+++ b/foreman/resource_foreman_image.go
@@ -53,17 +53,17 @@ func resourceForemanImage() *schema.Resource {
 			},
 			"compute_resource_id": {
 				Type:        schema.TypeInt,
-				Optional:    true,
+				Required:    true,
 				Description: "ID of the compute resource in Foreman",
 			},
 			"operatingsystem_id": {
 				Type:        schema.TypeInt,
-				Optional:    true,
+				Required:    true,
 				Description: "ID of the operating system in Foreman",
 			},
 			"architecture_id": {
 				Type:        schema.TypeInt,
-				Optional:    true,
+				Required:    true,
 				Description: "ID of the architecture in Foreman",
 			},
 			"user_data": {

--- a/foreman/resource_foreman_image.go
+++ b/foreman/resource_foreman_image.go
@@ -183,6 +183,14 @@ func resourceForemanImageUpdate(ctx context.Context, d *schema.ResourceData, met
 func resourceForemanImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Tracef("resource_foreman_image.go#Delete")
 
+	client := meta.(*api.Client)
+	image := buildForemanImage(d)
+
+	delErr := client.DeleteImage(ctx, image.ComputeResourceID, image.Id)
+	if delErr != nil {
+		return diag.FromErr(delErr)
+	}
+
 	// NOTE(ALL): d.SetId("") is automatically called by terraform assuming delete
 	//   returns no errors
 

--- a/foreman/resource_foreman_image_test.go
+++ b/foreman/resource_foreman_image_test.go
@@ -33,7 +33,7 @@ func ForemanImageToInstanceState(obj api.ForemanImage) *terraform.InstanceState 
 		"uuid":                obj.UUID,
 		"architecture_id":     strconv.Itoa(obj.ArchitectureID),
 		"compute_resource_id": strconv.Itoa(obj.ComputeResourceID),
-		"operating_system_id": strconv.Itoa(obj.OperatingSystemID),
+		"operatingsystem_id":  strconv.Itoa(obj.OperatingSystemID),
 	}
 	return &state
 }

--- a/foreman/resource_foreman_image_test.go
+++ b/foreman/resource_foreman_image_test.go
@@ -59,7 +59,6 @@ func RandForemanImage() api.ForemanImage {
 	fo := RandForemanObject()
 	return api.ForemanImage{
 		ForemanObject:     fo,
-		Name:              tfrand.String(10, tfrand.Lower),
 		Username:          tfrand.String(10, tfrand.Lower),
 		UUID:              tfrand.String(10, tfrand.Lower),
 		ArchitectureID:    rand.Intn(100),


### PR DESCRIPTION
This PR adds handling of Foreman images into the provider.

* Create: handle creation and error codes if UUID is already in use (tested on VMware backend)
* Delete: handle deletion of images in Foreman

Removes the `UnmarshalJSON` func for images, removing errors. 
Requires its own `json.RawMessage` marshalling func towards the API, the taxonomy wrapper produced errors.