### PR TITLE
Implement TraceFunctionCall; replace Tracef

### DIFF
--- a/foreman/api/architecture.go
+++ b/foreman/api/architecture.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -39,7 +40,7 @@ type foremanArchitectureJSON struct {
 // Custom JSON unmarshal function.  Unmarshal to the unexported JSON struct
 // and then convert over to a ForemanArchitecture struct.
 func (fa *ForemanArchitecture) UnmarshalJSON(b []byte) error {
-	log.Tracef("foreman/api/architecture.go#UnmarshalJSON")
+	utils.TraceFunctionCall()
 
 	var jsonDecErr error
 
@@ -71,7 +72,7 @@ func (fa *ForemanArchitecture) UnmarshalJSON(b []byte) error {
 // ForemanArchitecture reference.  The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateArchitecture(ctx context.Context, a *ForemanArchitecture) (*ForemanArchitecture, error) {
-	log.Tracef("foreman/api/architecture.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", ArchitectureEndpointPrefix)
 
@@ -106,7 +107,7 @@ func (c *Client) CreateArchitecture(ctx context.Context, a *ForemanArchitecture)
 // ReadArchitecture reads the attributes of a ForemanArchitecture identified by
 // the supplied ID and returns a ForemanArchitecture reference.
 func (c *Client) ReadArchitecture(ctx context.Context, id int) (*ForemanArchitecture, error) {
-	log.Tracef("foreman/api/architecture.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ArchitectureEndpointPrefix, id)
 
@@ -136,7 +137,7 @@ func (c *Client) ReadArchitecture(ctx context.Context, id int) (*ForemanArchitec
 // updated. A new ForemanArchitecture reference is returned with the attributes
 // from the result of the update operation.
 func (c *Client) UpdateArchitecture(ctx context.Context, a *ForemanArchitecture) (*ForemanArchitecture, error) {
-	log.Tracef("foreman/api/architecture.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ArchitectureEndpointPrefix, a.Id)
 
@@ -171,7 +172,7 @@ func (c *Client) UpdateArchitecture(ctx context.Context, a *ForemanArchitecture)
 // DeleteArchitecture deletes the ForemanArchitecture identified by the
 // supplied ID
 func (c *Client) DeleteArchitecture(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/architecture.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ArchitectureEndpointPrefix, id)
 
@@ -196,7 +197,7 @@ func (c *Client) DeleteArchitecture(ctx context.Context, id int) error {
 // of the supplied ForemanArchitecture reference and returns a QueryResponse
 // struct containing query/response metadata and the matching architectures.
 func (c *Client) QueryArchitecture(ctx context.Context, a *ForemanArchitecture) (QueryResponse, error) {
-	log.Tracef("foreman/api/architecture.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/client.go
+++ b/foreman/api/client.go
@@ -130,6 +130,7 @@ func ToKV(m map[string]interface{}) (ret []ForemanKVParameter) {
 // the API gateway.
 func NewClient(s Server, c ClientCredentials, cfg ClientConfig) *Client {
 	utils.TraceFunctionCall()
+
 	log.Debugf(
 		"Server: [%+v], "+
 			"ClientConfig: [%+v]",
@@ -200,6 +201,7 @@ func NewClient(s Server, c ClientCredentials, cfg ClientConfig) *Client {
 //	Functions exactly like net/http/NewRequestWithContext()
 func (client *Client) NewRequestWithContext(ctx context.Context, method string, endpoint string, body io.Reader) (*http.Request, error) {
 	utils.TraceFunctionCall()
+
 	log.Debugf(
 		"method: [%s], endpoint: [%s]",
 		method,
@@ -387,7 +389,6 @@ func CheckDeleted(d *schema.ResourceData, err error) error {
 
 // wrapParameter wraps the given parameters as an object of its own name
 func (client *Client) wrapParameters(name interface{}, item interface{}) (map[string]interface{}, error) {
-
 	var wrapped map[string]interface{}
 
 	if name != nil {
@@ -410,9 +411,7 @@ func (client *Client) wrapParameters(name interface{}, item interface{}) (map[st
 
 // WrapJSON wraps the given parameters as an object of its own name and marshals it to JSON
 func (client *Client) WrapJSON(name interface{}, item interface{}) ([]byte, error) {
-
 	wrapped, _ := client.wrapParameters(name, item)
-
 	return json.Marshal(wrapped)
 }
 

--- a/foreman/api/common_parameter.go
+++ b/foreman/api/common_parameter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -39,7 +40,7 @@ type ForemanCommonParameter struct {
 // The returned reference will have its ID and other API default values set by
 // this function.
 func (c *Client) CreateCommonParameter(ctx context.Context, d *ForemanCommonParameter) (*ForemanCommonParameter, error) {
-	log.Tracef("foreman/api/common_parameter.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := CommonParameterEndpointPrefix
 
@@ -77,7 +78,7 @@ func (c *Client) CreateCommonParameter(ctx context.Context, d *ForemanCommonPara
 // ReadCommonParameter reads the attributes of a ForemanCommonParameter identified by the
 // supplied ID and returns a ForemanCommonParameter reference.
 func (c *Client) ReadCommonParameter(ctx context.Context, d *ForemanCommonParameter, id int) (*ForemanCommonParameter, error) {
-	log.Tracef("foreman/api/common_parameter.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(CommonParameterEndpointPrefix+"/%d", id)
 
@@ -108,7 +109,7 @@ func (c *Client) ReadCommonParameter(ctx context.Context, d *ForemanCommonParame
 // UpdateCommonParameter deletes all commonParameters for the subject resource and re-creates them
 // as we look at them differently on either side this is the safest way to reach sync
 func (c *Client) UpdateCommonParameter(ctx context.Context, d *ForemanCommonParameter, id int) (*ForemanCommonParameter, error) {
-	log.Tracef("foreman/api/common_parameter.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(CommonParameterEndpointPrefix+"/%d", id)
 
@@ -145,7 +146,7 @@ func (c *Client) UpdateCommonParameter(ctx context.Context, d *ForemanCommonPara
 
 // DeleteCommonParameter deletes the ForemanCommonParameters for the given resource
 func (c *Client) DeleteCommonParameter(ctx context.Context, d *ForemanCommonParameter, id int) error {
-	log.Tracef("foreman/api/common_parameter.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(CommonParameterEndpointPrefix+"/%d", id)
 
@@ -170,7 +171,7 @@ func (c *Client) DeleteCommonParameter(ctx context.Context, d *ForemanCommonPara
 // supplied ForemanCommonParameter reference and returns a QueryResponse struct
 // containing query/response metadata and the matching commonParameters.
 func (c *Client) QueryCommonParameter(ctx context.Context, d *ForemanCommonParameter) (QueryResponse, error) {
-	log.Tracef("foreman/api/common_parameter.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/computeprofile.go
+++ b/foreman/api/computeprofile.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 	"strconv"
 
@@ -33,6 +34,8 @@ type ForemanComputeAttribute struct {
 // Implement custom Marshal function for ForemanComputeAttribute to convert
 // the internal vm_attrs map from all-string to their matching types.
 func (ca *ForemanComputeAttribute) MarshalJSON() ([]byte, error) {
+	utils.TraceFunctionCall()
+
 	fca := map[string]interface{}{
 		"id":                  ca.Id,
 		"name":                ca.Name,
@@ -101,7 +104,7 @@ func (ca *ForemanComputeAttribute) MarshalJSON() ([]byte, error) {
 // ReadComputeProfile reads the attributes of a ForemanComputeProfile identified by
 // the supplied ID and returns a ForemanComputeProfile reference.
 func (c *Client) ReadComputeProfile(ctx context.Context, id int) (*ForemanComputeProfile, error) {
-	log.Tracef("foreman/api/templatekind.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ComputeProfileEndpointPrefix, id)
 
@@ -138,7 +141,7 @@ func (c *Client) ReadComputeProfile(ctx context.Context, id int) (*ForemanComput
 // of the supplied ForemanComputeProfile reference and returns a QueryResponse
 // struct containing query/response metadata and the matching template kinds
 func (c *Client) QueryComputeProfile(ctx context.Context, t *ForemanComputeProfile) (QueryResponse, error) {
-	log.Tracef("foreman/api/templatekind.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 
@@ -191,7 +194,7 @@ func (c *Client) QueryComputeProfile(ctx context.Context, t *ForemanComputeProfi
 }
 
 func (c *Client) CreateComputeprofile(ctx context.Context, d *ForemanComputeProfile) (*ForemanComputeProfile, error) {
-	log.Tracef("foreman/api/computeprofile.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := ComputeProfileEndpointPrefix
 
@@ -257,7 +260,7 @@ func (c *Client) CreateComputeprofile(ctx context.Context, d *ForemanComputeProf
 }
 
 func (c *Client) UpdateComputeProfile(ctx context.Context, d *ForemanComputeProfile) (*ForemanComputeProfile, error) {
-	log.Tracef("foreman/api/computeprofile.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ComputeProfileEndpointPrefix, d.Id)
 
@@ -328,7 +331,7 @@ func (c *Client) UpdateComputeProfile(ctx context.Context, d *ForemanComputeProf
 }
 
 func (c *Client) DeleteComputeProfile(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/computeprofile.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ComputeProfileEndpointPrefix, id)
 	req, reqErr := c.NewRequestWithContext(ctx, http.MethodDelete, reqEndpoint, nil)

--- a/foreman/api/computeresource.go
+++ b/foreman/api/computeresource.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -44,6 +45,8 @@ type ForemanComputeResource struct {
 // Custom JSON unmarshal function. Unmarshal to the unexported JSON struct
 // and then convert over to a ForemanComputeResource struct.
 func (fcr *ForemanComputeResource) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -110,7 +113,7 @@ func (fcr *ForemanComputeResource) UnmarshalJSON(b []byte) error {
 // The returned reference will have its ID and other API default values set by
 // this function.
 func (c *Client) CreateComputeResource(ctx context.Context, d *ForemanComputeResource) (*ForemanComputeResource, error) {
-	log.Tracef("foreman/api/computeresource.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", ComputeResourceEndpointPrefix)
 
@@ -145,7 +148,7 @@ func (c *Client) CreateComputeResource(ctx context.Context, d *ForemanComputeRes
 // ReadComputeResource reads the attributes of a ForemanComputeResource identified by the
 // supplied ID and returns a ForemanComputeResource reference.
 func (c *Client) ReadComputeResource(ctx context.Context, id int) (*ForemanComputeResource, error) {
-	log.Tracef("foreman/api/computeresource.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ComputeResourceEndpointPrefix, id)
 
@@ -174,7 +177,7 @@ func (c *Client) ReadComputeResource(ctx context.Context, id int) (*ForemanCompu
 // of the supplied ForemanComputeResource will be updated. A new ForemanComputeResource reference
 // is returned with the attributes from the result of the update operation.
 func (c *Client) UpdateComputeResource(ctx context.Context, d *ForemanComputeResource) (*ForemanComputeResource, error) {
-	log.Tracef("foreman/api/computeresource.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ComputeResourceEndpointPrefix, d.Id)
 
@@ -208,7 +211,7 @@ func (c *Client) UpdateComputeResource(ctx context.Context, d *ForemanComputeRes
 
 // DeleteComputeResource deletes the ForemanComputeResource identified by the supplied ID
 func (c *Client) DeleteComputeResource(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/computeresource.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ComputeResourceEndpointPrefix, id)
 
@@ -233,7 +236,7 @@ func (c *Client) DeleteComputeResource(ctx context.Context, id int) error {
 // supplied ForemanComputeResource reference and returns a QueryResponse struct
 // containing query/response metadata and the matching computeresources.
 func (c *Client) QueryComputeResource(ctx context.Context, d *ForemanComputeResource) (QueryResponse, error) {
-	log.Tracef("foreman/api/computeresource.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/content_credential.go
+++ b/foreman/api/content_credential.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -39,7 +40,7 @@ type ForemanKatelloContentCredential struct {
 // ForemanKatelloContentCredential reference.  The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateKatelloContentCredential(ctx context.Context, s *ForemanKatelloContentCredential) (*ForemanKatelloContentCredential, error) {
-	log.Tracef("foreman/api/content_credential.go#Create")
+	utils.TraceFunctionCall()
 
 	sJSONBytes, jsonEncErr := c.WrapJSONWithTaxonomy(nil, s)
 	if jsonEncErr != nil {
@@ -72,7 +73,7 @@ func (c *Client) CreateKatelloContentCredential(ctx context.Context, s *ForemanK
 // ReadKatelloContentCredential reads the attributes of a ForemanKatelloContentCredential identified by the
 // supplied ID and returns a ForemanKatelloContentCredential reference.
 func (c *Client) ReadKatelloContentCredential(ctx context.Context, id int) (*ForemanKatelloContentCredential, error) {
-	log.Tracef("foreman/api/content_credential.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloContentCredentialEndpointPrefix, id)
 
@@ -102,7 +103,7 @@ func (c *Client) ReadKatelloContentCredential(ctx context.Context, id int) (*For
 // ForemanKatelloContentCredential reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateKatelloContentCredential(ctx context.Context, s *ForemanKatelloContentCredential) (*ForemanKatelloContentCredential, error) {
-	log.Tracef("foreman/api/content_credential.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloContentCredentialEndpointPrefix, s.Id)
 
@@ -136,7 +137,7 @@ func (c *Client) UpdateKatelloContentCredential(ctx context.Context, s *ForemanK
 
 // DeleteKatelloContentCredential deletes the ForemanKatelloContentCredential identified by the supplied ID
 func (c *Client) DeleteKatelloContentCredential(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/content_credential.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloContentCredentialEndpointPrefix, id)
 
@@ -161,7 +162,7 @@ func (c *Client) DeleteKatelloContentCredential(ctx context.Context, id int) err
 // the supplied ForemanKatelloContentCredential reference and returns a QueryResponse struct
 // containing query/response metadata and the matching smart proxy.
 func (c *Client) QueryKatelloContentCredential(ctx context.Context, s *ForemanKatelloContentCredential) (QueryResponse, error) {
-	log.Tracef("foreman/api/content_credential.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/defaulttemplate.go
+++ b/foreman/api/defaulttemplate.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -38,7 +39,7 @@ type ForemanDefaultTemplate struct {
 // The returned reference will have its ID and other API default values set by
 // this function.
 func (c *Client) CreateDefaultTemplate(ctx context.Context, d *ForemanDefaultTemplate) (*ForemanDefaultTemplate, error) {
-	log.Tracef("foreman/api/parameter.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(DefaultTemplateEndpointPrefix, d.OperatingSystemId)
 
@@ -74,7 +75,7 @@ func (c *Client) CreateDefaultTemplate(ctx context.Context, d *ForemanDefaultTem
 // ReadDefaultTemplate reads the attributes of a ForemanDefaultTemplate identified by the
 // supplied ID and returns a ForemanDefaultTemplate reference.
 func (c *Client) ReadDefaultTemplate(ctx context.Context, d *ForemanDefaultTemplate, id int) (*ForemanDefaultTemplate, error) {
-	log.Tracef("foreman/api/parameter.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(DefaultTemplateEndpointPrefix+"/%d", d.OperatingSystemId, id)
 
@@ -102,7 +103,7 @@ func (c *Client) ReadDefaultTemplate(ctx context.Context, d *ForemanDefaultTempl
 // UpdateDefaultTemplate deletes all parameters for the subject resource and re-creates them
 // as we look at them differently on either side this is the safest way to reach sync
 func (c *Client) UpdateDefaultTemplate(ctx context.Context, d *ForemanDefaultTemplate, id int) (*ForemanDefaultTemplate, error) {
-	log.Tracef("foreman/api/parameter.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(DefaultTemplateEndpointPrefix+"/%d", d.OperatingSystemId, id)
 	wrapped, _ := c.wrapParameters("os_default_template", d)
@@ -137,7 +138,7 @@ func (c *Client) UpdateDefaultTemplate(ctx context.Context, d *ForemanDefaultTem
 
 // DeleteDefaultTemplate deletes the ForemanDefaultTemplates for the given resource
 func (c *Client) DeleteDefaultTemplate(ctx context.Context, d *ForemanDefaultTemplate, id int) error {
-	log.Tracef("foreman/api/parameter.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(DefaultTemplateEndpointPrefix+"/%d", d.OperatingSystemId, id)
 
@@ -162,7 +163,7 @@ func (c *Client) DeleteDefaultTemplate(ctx context.Context, d *ForemanDefaultTem
 // supplied ForemanDefaultTemplate reference and returns a QueryResponse struct
 // containing query/response metadata and the matching parameters.
 func (c *Client) QueryDefaultTemplate(ctx context.Context, d *ForemanDefaultTemplate) (QueryResponse, error) {
-	log.Tracef("foreman/api/parameter.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/domain.go
+++ b/foreman/api/domain.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -41,7 +42,7 @@ type ForemanDomain struct {
 // The returned reference will have its ID and other API default values set by
 // this function.
 func (c *Client) CreateDomain(ctx context.Context, d *ForemanDomain) (*ForemanDomain, error) {
-	log.Tracef("foreman/api/domain.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", DomainEndpointPrefix)
 
@@ -76,7 +77,7 @@ func (c *Client) CreateDomain(ctx context.Context, d *ForemanDomain) (*ForemanDo
 // ReadDomain reads the attributes of a ForemanDomain identified by the
 // supplied ID and returns a ForemanDomain reference.
 func (c *Client) ReadDomain(ctx context.Context, id int) (*ForemanDomain, error) {
-	log.Tracef("foreman/api/domain.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", DomainEndpointPrefix, id)
 
@@ -105,7 +106,7 @@ func (c *Client) ReadDomain(ctx context.Context, id int) (*ForemanDomain, error)
 // of the supplied ForemanDomain will be updated. A new ForemanDomain reference
 // is returned with the attributes from the result of the update operation.
 func (c *Client) UpdateDomain(ctx context.Context, d *ForemanDomain, id int) (*ForemanDomain, error) {
-	log.Tracef("foreman/api/domain.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", DomainEndpointPrefix, id)
 
@@ -139,7 +140,7 @@ func (c *Client) UpdateDomain(ctx context.Context, d *ForemanDomain, id int) (*F
 
 // DeleteDomain deletes the ForemanDomain identified by the supplied ID
 func (c *Client) DeleteDomain(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/domain.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", DomainEndpointPrefix, id)
 
@@ -164,7 +165,7 @@ func (c *Client) DeleteDomain(ctx context.Context, id int) error {
 // supplied ForemanDomain reference and returns a QueryResponse struct
 // containing query/response metadata and the matching domains.
 func (c *Client) QueryDomain(ctx context.Context, d *ForemanDomain) (QueryResponse, error) {
-	log.Tracef("foreman/api/domain.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/environment.go
+++ b/foreman/api/environment.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -33,7 +34,7 @@ type ForemanEnvironment struct {
 // ForemanEnvironment reference.  The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateEnvironment(ctx context.Context, e *ForemanEnvironment) (*ForemanEnvironment, error) {
-	log.Tracef("foreman/api/environment.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", EnvironmentEndpointPrefix)
 
@@ -68,7 +69,7 @@ func (c *Client) CreateEnvironment(ctx context.Context, e *ForemanEnvironment) (
 // ReadEnvironment reads the attributes of a ForemanEnvironment identified by
 // the supplied ID and returns a ForemanEnvironment reference.
 func (c *Client) ReadEnvironment(ctx context.Context, id int) (*ForemanEnvironment, error) {
-	log.Tracef("foreman/api/environment.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", EnvironmentEndpointPrefix, id)
 
@@ -98,7 +99,7 @@ func (c *Client) ReadEnvironment(ctx context.Context, id int) (*ForemanEnvironme
 // A new ForemanEnvironment reference is returned with the attributes from the
 // result of the update operation.
 func (c *Client) UpdateEnvironment(ctx context.Context, e *ForemanEnvironment) (*ForemanEnvironment, error) {
-	log.Tracef("foreman/api/environment.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", EnvironmentEndpointPrefix, e.Id)
 
@@ -133,7 +134,7 @@ func (c *Client) UpdateEnvironment(ctx context.Context, e *ForemanEnvironment) (
 // DeleteEnvironment deletes the ForemanEnvironment identified by the supplied
 // ID
 func (c *Client) DeleteEnvironment(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/environment.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", EnvironmentEndpointPrefix, id)
 
@@ -158,7 +159,7 @@ func (c *Client) DeleteEnvironment(ctx context.Context, id int) error {
 // the supplied ForemanEnvironment reference and returns a QueryResponse struct
 // containing query/response metadata and the matching environments.
 func (c *Client) QueryEnvironment(ctx context.Context, e *ForemanEnvironment) (QueryResponse, error) {
-	log.Tracef("foreman/api/environment.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 	"strings"
 
@@ -199,6 +200,8 @@ type BMCBoot struct {
 //
 // Example: https://<foreman>/api/hosts/<hostname>/boot
 func (c *Client) SendPowerCommand(ctx context.Context, h *ForemanHost, cmd interface{}, retryCount int) error {
+	utils.TraceFunctionCall()
+
 	// Initialize suffix variable,
 	suffix := ""
 
@@ -266,7 +269,7 @@ func (c *Client) SendPowerCommand(ctx context.Context, h *ForemanHost, cmd inter
 // returned reference will have its ID and other API default values set by this
 // function.
 func (c *Client) CreateHost(ctx context.Context, h *ForemanHost, retryCount int) (*ForemanHost, error) {
-	log.Tracef("foreman/api/host.go#CreateHost")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", HostEndpointPrefix)
 
@@ -329,7 +332,7 @@ func (c *Client) CreateHost(ctx context.Context, h *ForemanHost, retryCount int)
 // ReadHost reads the attributes of a ForemanHost identified by the supplied ID
 // and returns a ForemanHost reference.
 func (c *Client) ReadHost(ctx context.Context, id int) (*ForemanHost, error) {
-	log.Tracef("foreman/api/host.go#ReadHost")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostEndpointPrefix, id)
 
@@ -369,7 +372,7 @@ func (c *Client) ReadHost(ctx context.Context, id int) (*ForemanHost, error) {
 // supplied ForemanHost will be updated. A new ForemanHost reference is
 // returned with the attributes from the result of the update operation.
 func (c *Client) UpdateHost(ctx context.Context, h *ForemanHost, retryCount int) (*ForemanHost, error) {
-	log.Tracef("foreman/api/host.go#UpdateHost")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostEndpointPrefix, h.Id)
 
@@ -428,7 +431,7 @@ func (c *Client) UpdateHost(ctx context.Context, h *ForemanHost, retryCount int)
 
 // DeleteHost deletes the ForemanHost identified by the supplied ID
 func (c *Client) DeleteHost(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/host.go#DeleteHost")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostEndpointPrefix, id)
 
@@ -447,7 +450,7 @@ func (c *Client) DeleteHost(ctx context.Context, id int) error {
 
 // Compute Attributes are only available via dedicated API endpoint. readComputeAttributes gets this endpoint.
 func (c *Client) readComputeAttributes(ctx context.Context, id int) (map[string]interface{}, error) {
-	log.Tracef("foreman/api/host.go#readComputeAttributes")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d/%s", HostEndpointPrefix, id, ComputeAttributesSuffix)
 
@@ -476,7 +479,7 @@ func (c *Client) readComputeAttributes(ctx context.Context, id int) (map[string]
 }
 
 func constructShortname(host *foremanHostDecode) error {
-	log.Tracef("foreman/api/host.go#constructShortname")
+	utils.TraceFunctionCall()
 
 	// Construct shortname from 'name'
 	if host.Shortname == "" {

--- a/foreman/api/hostgroup.go
+++ b/foreman/api/hostgroup.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -100,7 +101,7 @@ type foremanHostGroupDecode struct {
 // reference.  The returned reference will have its ID and other API default
 // values set by this function.
 func (c *Client) CreateHostgroup(ctx context.Context, h *ForemanHostgroup) (*ForemanHostgroup, error) {
-	log.Tracef("foreman/api/hostgroup.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", HostgroupEndpointPrefix)
 
@@ -135,7 +136,7 @@ func (c *Client) CreateHostgroup(ctx context.Context, h *ForemanHostgroup) (*For
 // ReadHostgroup reads the attributes of a ForemanHostgroup identified by the
 // supplied ID and returns a ForemanHostgroup reference.
 func (c *Client) ReadHostgroup(ctx context.Context, id int) (*ForemanHostgroup, error) {
-	log.Tracef("foreman/api/hostgroup.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostgroupEndpointPrefix, id)
 
@@ -169,7 +170,7 @@ func (c *Client) ReadHostgroup(ctx context.Context, id int) (*ForemanHostgroup, 
 // ForemanHostgroup reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateHostgroup(ctx context.Context, h *ForemanHostgroup) (*ForemanHostgroup, error) {
-	log.Tracef("foreman/api/hostgroup.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostgroupEndpointPrefix, h.Id)
 
@@ -207,7 +208,7 @@ func (c *Client) UpdateHostgroup(ctx context.Context, h *ForemanHostgroup) (*For
 
 // DeleteHostgroup deletes the ForemanHostgroup identified by the supplied ID
 func (c *Client) DeleteHostgroup(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/hostgroup.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostgroupEndpointPrefix, id)
 
@@ -232,7 +233,7 @@ func (c *Client) DeleteHostgroup(ctx context.Context, id int) error {
 // supplied ForemanHostgroup reference and returns a QueryResponse struct
 // containing query/response metadata and the matching hostgroups.
 func (c *Client) QueryHostgroup(ctx context.Context, h *ForemanHostgroup) (QueryResponse, error) {
-	log.Tracef("foreman/api/hostgroup.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/httpproxy.go
+++ b/foreman/api/httpproxy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -37,7 +38,7 @@ type ForemanHTTPProxy struct {
 // ForemanHTTPProxy reference.  The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateHTTPProxy(ctx context.Context, s *ForemanHTTPProxy) (*ForemanHTTPProxy, error) {
-	log.Tracef("foreman/api/httpproxy.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", HTTPProxyEndpointPrefix)
 
@@ -72,7 +73,7 @@ func (c *Client) CreateHTTPProxy(ctx context.Context, s *ForemanHTTPProxy) (*For
 // ReadHTTPProxy reads the attributes of a ForemanHTTPProxy identified by the
 // supplied ID and returns a ForemanHTTPProxy reference.
 func (c *Client) ReadHTTPProxy(ctx context.Context, id int) (*ForemanHTTPProxy, error) {
-	log.Tracef("foreman/api/HTTPProxy.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HTTPProxyEndpointPrefix, id)
 
@@ -102,7 +103,7 @@ func (c *Client) ReadHTTPProxy(ctx context.Context, id int) (*ForemanHTTPProxy, 
 // ForemanHTTPProxy reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateHTTPProxy(ctx context.Context, s *ForemanHTTPProxy) (*ForemanHTTPProxy, error) {
-	log.Tracef("foreman/api/HTTPProxy.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HTTPProxyEndpointPrefix, s.Id)
 
@@ -136,7 +137,7 @@ func (c *Client) UpdateHTTPProxy(ctx context.Context, s *ForemanHTTPProxy) (*For
 
 // DeleteHTTPProxy deletes the ForemanHTTPProxy identified by the supplied ID
 func (c *Client) DeleteHTTPProxy(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/HTTPProxy.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HTTPProxyEndpointPrefix, id)
 
@@ -161,7 +162,7 @@ func (c *Client) DeleteHTTPProxy(ctx context.Context, id int) error {
 // the supplied ForemanHTTPProxy reference and returns a QueryResponse struct
 // containing query/response metadata and the matching smart proxy.
 func (c *Client) QueryHTTPProxy(ctx context.Context, s *ForemanHTTPProxy) (QueryResponse, error) {
-	log.Tracef("foreman/api/HTTPProxy.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/image.go
+++ b/foreman/api/image.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -42,6 +43,8 @@ type ForemanImage struct {
 }
 
 func (fi *ForemanImage) MarshalJSON() ([]byte, error) {
+	utils.TraceFunctionCall()
+
 	fim := map[string]interface{}{
 		"uuid":                fi.UUID,
 		"name":                fi.Name,
@@ -63,7 +66,7 @@ func (fi *ForemanImage) MarshalJSON() ([]byte, error) {
 // The returned reference will have its ID and other API default values set by
 // this function.
 func (c *Client) CreateImage(ctx context.Context, d *ForemanImage, compute_resource int) (*ForemanImage, error) {
-	log.Tracef("foreman/api/image.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d/images", ComputeResourceEndpoint, compute_resource)
 
@@ -102,7 +105,7 @@ func (c *Client) CreateImage(ctx context.Context, d *ForemanImage, compute_resou
 // ReadImage reads the attributes of a ForemanImage identified by the
 // supplied ID and returns a ForemanImage reference.
 func (c *Client) ReadImage(ctx context.Context, d *ForemanImage) (*ForemanImage, error) {
-	log.Tracef("foreman/api/image.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d/images/%d", ComputeResourceEndpoint, d.ComputeResourceID, d.Id)
 
@@ -131,7 +134,7 @@ func (c *Client) ReadImage(ctx context.Context, d *ForemanImage) (*ForemanImage,
 // of the supplied ForemanImage will be updated. A new ForemanImage reference
 // is returned with the attributes from the result of the update operation.
 func (c *Client) UpdateImage(ctx context.Context, d *ForemanImage) (*ForemanImage, error) {
-	log.Tracef("foreman/api/image.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d/images/%d", ComputeResourceEndpoint, d.ComputeResourceID, d.Id)
 
@@ -165,7 +168,7 @@ func (c *Client) UpdateImage(ctx context.Context, d *ForemanImage) (*ForemanImag
 
 // DeleteImage deletes the ForemanImage identified by the supplied ID
 func (c *Client) DeleteImage(ctx context.Context, compute_resource, id int) error {
-	log.Tracef("foreman/api/image.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d/images/%d", ComputeResourceEndpoint, compute_resource, id)
 
@@ -190,7 +193,7 @@ func (c *Client) DeleteImage(ctx context.Context, compute_resource, id int) erro
 // supplied ForemanImage reference and returns a QueryResponse struct
 // containing query/response metadata and the matching images.
 func (c *Client) QueryImage(ctx context.Context, d *ForemanImage) (QueryResponse, error) {
-	log.Tracef("foreman/api/image.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/job_template.go
+++ b/foreman/api/job_template.go
@@ -207,9 +207,9 @@ func (c *Client) UpdateJobTemplate(ctx context.Context, jtObj *ForemanJobTemplat
 
 	// Handle TemplateInputs
 
-	count_ti := len(jtObj.TemplateInputs)
-	if count_ti > 0 {
-		updatedTIs := make([]ForemanTemplateInput, count_ti)
+	countTi := len(jtObj.TemplateInputs)
+	if countTi > 0 {
+		updatedTIs := make([]ForemanTemplateInput, countTi)
 
 		for idx, item := range jtObj.TemplateInputs {
 			ti, err := c.UpdateTemplateInput(ctx, &item)

--- a/foreman/api/media.go
+++ b/foreman/api/media.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -52,6 +53,8 @@ type foremanMediaJSON struct {
 
 // Implement the Unmarshaler interface
 func (fm *ForemanMedia) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -97,7 +100,7 @@ func (fm *ForemanMedia) UnmarshalJSON(b []byte) error {
 // returned reference will have its ID and other API default values set by this
 // function.
 func (c *Client) CreateMedia(ctx context.Context, m *ForemanMedia) (*ForemanMedia, error) {
-	log.Tracef("foreman/api/media.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", MediaEndpointPrefix)
 
@@ -132,7 +135,7 @@ func (c *Client) CreateMedia(ctx context.Context, m *ForemanMedia) (*ForemanMedi
 // ReadMedia reads the attributes of a ForemanMedia identified by the supplied
 // ID and returns a ForemanMedia reference.
 func (c *Client) ReadMedia(ctx context.Context, id int) (*ForemanMedia, error) {
-	log.Tracef("foreman/api/media.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", MediaEndpointPrefix, id)
 
@@ -161,7 +164,7 @@ func (c *Client) ReadMedia(ctx context.Context, id int) (*ForemanMedia, error) {
 // the supplied ForemanMedia will be updated. A new ForemanMedia reference is
 // returned with the attributes from the result of the update operation.
 func (c *Client) UpdateMedia(ctx context.Context, m *ForemanMedia) (*ForemanMedia, error) {
-	log.Tracef("foreman/api/media.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", MediaEndpointPrefix, m.Id)
 
@@ -195,7 +198,7 @@ func (c *Client) UpdateMedia(ctx context.Context, m *ForemanMedia) (*ForemanMedi
 
 // DeleteMedia deletes the ForemanMedia identified by the supplied ID
 func (c *Client) DeleteMedia(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/media.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", MediaEndpointPrefix, id)
 
@@ -220,7 +223,7 @@ func (c *Client) DeleteMedia(ctx context.Context, id int) error {
 // supplied ForemanMedia reference and returns a QueryResponse struct
 // containing query/response metadata and the matching media.
 func (c *Client) QueryMedia(ctx context.Context, m *ForemanMedia) (QueryResponse, error) {
-	log.Tracef("foreman/api/media.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/model.go
+++ b/foreman/api/model.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -40,7 +41,7 @@ type ForemanModel struct {
 // returned reference will have its ID and other API default values set by this
 // function.
 func (c *Client) CreateModel(ctx context.Context, m *ForemanModel) (*ForemanModel, error) {
-	log.Tracef("foreman/api/model.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", ModelEndpointPrefix)
 
@@ -75,7 +76,7 @@ func (c *Client) CreateModel(ctx context.Context, m *ForemanModel) (*ForemanMode
 // ReadModel reads the attributes of a ForemanModel identified by the supplied
 // ID and returns a ForemanModel reference.
 func (c *Client) ReadModel(ctx context.Context, id int) (*ForemanModel, error) {
-	log.Tracef("foreman/api/model.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ModelEndpointPrefix, id)
 
@@ -104,7 +105,7 @@ func (c *Client) ReadModel(ctx context.Context, id int) (*ForemanModel, error) {
 // the supplied ForemanModel will be updated. A new ForemanModel reference is
 // returned with the attributes from the result of the update operation.
 func (c *Client) UpdateModel(ctx context.Context, m *ForemanModel) (*ForemanModel, error) {
-	log.Tracef("foreman/api/model.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ModelEndpointPrefix, m.Id)
 
@@ -138,7 +139,7 @@ func (c *Client) UpdateModel(ctx context.Context, m *ForemanModel) (*ForemanMode
 
 // DeleteModel deletes the ForemanModel identified by the supplied ID
 func (c *Client) DeleteModel(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/model.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ModelEndpointPrefix, id)
 
@@ -163,7 +164,7 @@ func (c *Client) DeleteModel(ctx context.Context, id int) error {
 // supplied ForemanModel reference and returns a QueryResponse struct
 // containing query/response metadata and the matching model.
 func (c *Client) QueryModel(ctx context.Context, m *ForemanModel) (QueryResponse, error) {
-	log.Tracef("foreman/api/model.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/operatingsystem.go
+++ b/foreman/api/operatingsystem.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -67,6 +68,8 @@ type foremanOsRespJSON struct {
 
 // Implement the Unmarshaler interface
 func (o *ForemanOperatingSystem) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -132,7 +135,7 @@ func (o *ForemanOperatingSystem) UnmarshalJSON(b []byte) error {
 // created ForemanOperatingSystem reference.  The returned reference will have
 // its ID and other API default values set by this function.
 func (c *Client) CreateOperatingSystem(ctx context.Context, o *ForemanOperatingSystem) (*ForemanOperatingSystem, error) {
-	log.Tracef("foreman/api/operatingsystem.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", OperatingSystemEndpointPrefix)
 
@@ -168,7 +171,7 @@ func (c *Client) CreateOperatingSystem(ctx context.Context, o *ForemanOperatingS
 // identified by the supplied ID and returns a ForemanOperatingSystem
 // reference.
 func (c *Client) ReadOperatingSystem(ctx context.Context, id int) (*ForemanOperatingSystem, error) {
-	log.Tracef("foreman/api/operatingsystem.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", OperatingSystemEndpointPrefix, id)
 
@@ -198,7 +201,7 @@ func (c *Client) ReadOperatingSystem(ctx context.Context, id int) (*ForemanOpera
 // updated. A new ForemanOperatingSystem reference is returned with the
 // attributes from the result of the update operation.
 func (c *Client) UpdateOperatingSystem(ctx context.Context, o *ForemanOperatingSystem) (*ForemanOperatingSystem, error) {
-	log.Tracef("foreman/api/operatingsystem.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", OperatingSystemEndpointPrefix, o.Id)
 
@@ -233,7 +236,7 @@ func (c *Client) UpdateOperatingSystem(ctx context.Context, o *ForemanOperatingS
 // DeleteOperatingSystem deletes the ForemanOperatingSystem identified by the
 // supplied ID
 func (c *Client) DeleteOperatingSystem(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/operatingsystem.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", OperatingSystemEndpointPrefix, id)
 
@@ -259,7 +262,7 @@ func (c *Client) DeleteOperatingSystem(ctx context.Context, id int) error {
 // QueryResponse struct containing query/response metadata and the matching
 // operating systems.
 func (c *Client) QueryOperatingSystem(ctx context.Context, o *ForemanOperatingSystem) (QueryResponse, error) {
-	log.Tracef("foreman/api/operatingsystem.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/override_value.go
+++ b/foreman/api/override_value.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 	"strconv"
 	"strings"
@@ -39,7 +40,7 @@ type ForemanOverrideValue struct {
 
 // Implement the Marshaler interface
 func (ov ForemanOverrideValue) MarshalJSON() ([]byte, error) {
-	log.Tracef("foreman/api/override_value.go#MarshalJSON")
+	utils.TraceFunctionCall()
 
 	ovMap := map[string]interface{}{}
 	ovMap["omit"] = ov.Omit
@@ -57,7 +58,7 @@ func (ov ForemanOverrideValue) MarshalJSON() ([]byte, error) {
 	}
 	if err != nil {
 		ovMap["value"] = ov.Value
-		log.Tracef("foreman/api/override_value.go#MarshalJSON/passraw")
+		log.Debugf("override_value.go #MarshalJSON/passraw")
 	}
 
 	log.Debugf("ovMap: [%+v]", ovMap)
@@ -68,6 +69,8 @@ func (ov ForemanOverrideValue) MarshalJSON() ([]byte, error) {
 // Custom JSON unmarshal function. Unmarshal to the unexported JSON struct
 // and then convert over to a ForemanHost struct.
 func (ov *ForemanOverrideValue) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -108,7 +111,7 @@ func (ov *ForemanOverrideValue) UnmarshalJSON(b []byte) error {
 		ov.MatchValue = strings.TrimPrefix(match, "os=")
 	}
 
-	log.Tracef("foreman/api/override_value.go#UnarshalJSON/postMatch")
+	log.Debugf("override_value.go #UnmarshalJSON/postMatch")
 
 	if ov.Omit, ok = tmpMap["omit"].(bool); !ok {
 		ov.Omit = false
@@ -119,7 +122,7 @@ func (ov *ForemanOverrideValue) UnmarshalJSON(b []byte) error {
 		ov.Value = string(vb)
 	}
 
-	log.Tracef("foreman/api/override_value.go#UnarshalJSON/postValue")
+	log.Debugf("override_value.go #UnmarshalJSON/postValue")
 
 	return nil
 }
@@ -133,7 +136,7 @@ func (ov *ForemanOverrideValue) UnmarshalJSON(b []byte) error {
 // returned reference will have its ID and other API default values set by this
 // function.
 func (c *Client) CreateOverrideValue(ctx context.Context, ov *ForemanOverrideValue) (*ForemanOverrideValue, error) {
-	log.Tracef("foreman/api/override_value.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(OverrideValueEndpointPrefix, ov.SmartClassParameterId)
 
@@ -173,7 +176,7 @@ func (c *Client) CreateOverrideValue(ctx context.Context, ov *ForemanOverrideVal
 // NOTE - although override value ids appear to be unique the API requires the smart
 // class parameter id as well.
 func (c *Client) ReadOverrideValue(ctx context.Context, id int, scp_id int) (*ForemanOverrideValue, error) {
-	log.Tracef("foreman/api/override_value.go#Read")
+	utils.TraceFunctionCall()
 
 	// Build the API endpoint
 	reqEndpoint := fmt.Sprintf(OverrideValueEndpointPrefix+"/%d", scp_id, id)
@@ -202,7 +205,7 @@ func (c *Client) ReadOverrideValue(ctx context.Context, id int, scp_id int) (*Fo
 
 // UpdateOverrideValue updates a ForemanOverrideValue's attributes.
 func (c *Client) UpdateOverrideValue(ctx context.Context, ov *ForemanOverrideValue) (*ForemanOverrideValue, error) {
-	log.Tracef("foreman/api/override_value.go#Update")
+	utils.TraceFunctionCall()
 
 	// Build the API endpoint
 	reqEndpoint := fmt.Sprintf(OverrideValueEndpointPrefix+"/%d", ov.SmartClassParameterId, ov.Id)
@@ -240,7 +243,7 @@ func (c *Client) UpdateOverrideValue(ctx context.Context, ov *ForemanOverrideVal
 
 // DeleteOverideValue deletes the ForemanOverrideValue identified by the supplied ID and smarts class param ID
 func (c *Client) DeleteOverrideValue(ctx context.Context, id int, scp_id int) error {
-	log.Tracef("foreman/api/override_value.go#Delete")
+	utils.TraceFunctionCall()
 
 	// Build the API endpoint
 	reqEndpoint := fmt.Sprintf(OverrideValueEndpointPrefix+"/%d", scp_id, id)
@@ -262,6 +265,6 @@ func (c *Client) DeleteOverrideValue(ctx context.Context, id int, scp_id int) er
 // Query Implementation
 // -----------------------------------------------------------------------------
 
-// Doesn't lool like this is possible in the API
+// Doesn't look like this is possible in the API
 // The only field it makes sense to search on is match, but this is not supported
 // So we cannot have a data object, only resource

--- a/foreman/api/parameter.go
+++ b/foreman/api/parameter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -51,6 +52,8 @@ func (fp *ForemanParameter) apiEndpoint() (string, int) {
 }
 
 func (fp *ForemanParameter) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -87,7 +90,7 @@ func (fp *ForemanParameter) UnmarshalJSON(b []byte) error {
 // The returned reference will have its ID and other API default values set by
 // this function.
 func (c *Client) CreateParameter(ctx context.Context, d *ForemanParameter) (*ForemanParameter, error) {
-	log.Tracef("foreman/api/parameter.go#Create")
+	utils.TraceFunctionCall()
 
 	selEndA, selEndB := d.apiEndpoint()
 	reqEndpoint := fmt.Sprintf(ParameterEndpointPrefix, selEndA, selEndB)
@@ -125,7 +128,7 @@ func (c *Client) CreateParameter(ctx context.Context, d *ForemanParameter) (*For
 // ReadParameter reads the attributes of a ForemanParameter identified by the
 // supplied ID and returns a ForemanParameter reference.
 func (c *Client) ReadParameter(ctx context.Context, d *ForemanParameter, id int) (*ForemanParameter, error) {
-	log.Tracef("foreman/api/parameter.go#Read")
+	utils.TraceFunctionCall()
 
 	selEndA, selEndB := d.apiEndpoint()
 	reqEndpoint := fmt.Sprintf(ParameterEndpointPrefix+"/%d", selEndA, selEndB, id)
@@ -156,7 +159,7 @@ func (c *Client) ReadParameter(ctx context.Context, d *ForemanParameter, id int)
 // UpdateParameter deletes all parameters for the subject resource and re-creates them
 // as we look at them differently on either side this is the safest way to reach sync
 func (c *Client) UpdateParameter(ctx context.Context, d *ForemanParameter, id int) (*ForemanParameter, error) {
-	log.Tracef("foreman/api/parameter.go#Update")
+	utils.TraceFunctionCall()
 
 	selEndA, selEndB := d.apiEndpoint()
 	reqEndpoint := fmt.Sprintf(ParameterEndpointPrefix+"/%d", selEndA, selEndB, id)
@@ -193,7 +196,7 @@ func (c *Client) UpdateParameter(ctx context.Context, d *ForemanParameter, id in
 
 // DeleteParameter deletes the ForemanParameters for the given resource
 func (c *Client) DeleteParameter(ctx context.Context, d *ForemanParameter, id int) error {
-	log.Tracef("foreman/api/parameter.go#Delete")
+	utils.TraceFunctionCall()
 
 	selEndA, selEndB := d.apiEndpoint()
 	reqEndpoint := fmt.Sprintf(ParameterEndpointPrefix+"/%d", selEndA, selEndB, id)
@@ -219,7 +222,7 @@ func (c *Client) DeleteParameter(ctx context.Context, d *ForemanParameter, id in
 // supplied ForemanParameter reference and returns a QueryResponse struct
 // containing query/response metadata and the matching parameters.
 func (c *Client) QueryParameter(ctx context.Context, d *ForemanParameter) (QueryResponse, error) {
-	log.Tracef("foreman/api/parameter.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/partitiontable.go
+++ b/foreman/api/partitiontable.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -58,6 +59,8 @@ type foremanPartitionTableJSON struct {
 
 // Implement the Unmarshaler interface
 func (ft *ForemanPartitionTable) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -112,7 +115,7 @@ func (ft *ForemanPartitionTable) UnmarshalJSON(b []byte) error {
 // ForemanPartitionTable reference.  The returned reference will have its ID
 // and other API default values set by this function.
 func (c *Client) CreatePartitionTable(ctx context.Context, t *ForemanPartitionTable) (*ForemanPartitionTable, error) {
-	log.Tracef("foreman/api/partitiontable.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", PartitionTableEndpointPrefix)
 
@@ -147,7 +150,7 @@ func (c *Client) CreatePartitionTable(ctx context.Context, t *ForemanPartitionTa
 // ReadPartitionTable reads the attributes of a ForemanPartitionTable
 // identified by the supplied ID and returns a ForemanPartitionTable reference.
 func (c *Client) ReadPartitionTable(ctx context.Context, id int) (*ForemanPartitionTable, error) {
-	log.Tracef("foreman/api/partitiontable.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", PartitionTableEndpointPrefix, id)
 
@@ -177,7 +180,7 @@ func (c *Client) ReadPartitionTable(ctx context.Context, id int) (*ForemanPartit
 // updated. A new ForemanPartitionTable reference is returned with the
 // attributes from the result of the update operation.
 func (c *Client) UpdatePartitionTable(ctx context.Context, t *ForemanPartitionTable) (*ForemanPartitionTable, error) {
-	log.Tracef("foreman/api/partitiontable.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", PartitionTableEndpointPrefix, t.Id)
 
@@ -212,7 +215,7 @@ func (c *Client) UpdatePartitionTable(ctx context.Context, t *ForemanPartitionTa
 // DeletePartitionTable deletes the ForemanPartitionTable identified by the
 // supplied ID
 func (c *Client) DeletePartitionTable(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/partitiontable.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", PartitionTableEndpointPrefix, id)
 
@@ -238,7 +241,7 @@ func (c *Client) DeletePartitionTable(ctx context.Context, id int) error {
 // QueryResponse struct containing query/response metadata and the matching
 // partition tables.
 func (c *Client) QueryPartitionTable(ctx context.Context, t *ForemanPartitionTable) (QueryResponse, error) {
-	log.Tracef("foreman/api/partitiontable.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/product.go
+++ b/foreman/api/product.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 	"strconv"
 
@@ -44,7 +45,7 @@ type ForemanKatelloProduct struct {
 // ForemanKatelloProduct reference. The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateKatelloProduct(ctx context.Context, p *ForemanKatelloProduct) (*ForemanKatelloProduct, error) {
-	log.Tracef("foreman/api/product.go#Create")
+	utils.TraceFunctionCall()
 
 	sJSONBytes, jsonEncErr := c.WrapJSON(nil, p)
 	if jsonEncErr != nil {
@@ -83,7 +84,7 @@ func (c *Client) CreateKatelloProduct(ctx context.Context, p *ForemanKatelloProd
 // ReadKatelloProduct reads the attributes of a ForemanKatelloProduct identified by the
 // supplied ID and returns a ForemanKatelloProduct reference.
 func (c *Client) ReadKatelloProduct(ctx context.Context, id int) (*ForemanKatelloProduct, error) {
-	log.Tracef("foreman/api/product.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloProductEndpointPrefix, id)
 
@@ -113,7 +114,7 @@ func (c *Client) ReadKatelloProduct(ctx context.Context, id int) (*ForemanKatell
 // ForemanKatelloProduct reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateKatelloProduct(ctx context.Context, p *ForemanKatelloProduct) (*ForemanKatelloProduct, error) {
-	log.Tracef("foreman/api/product.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloProductEndpointPrefix, p.Id)
 
@@ -147,7 +148,7 @@ func (c *Client) UpdateKatelloProduct(ctx context.Context, p *ForemanKatelloProd
 
 // DeleteKatelloProduct deletes the ForemanKatelloProduct identified by the supplied ID
 func (c *Client) DeleteKatelloProduct(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/product.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloProductEndpointPrefix, id)
 
@@ -172,7 +173,7 @@ func (c *Client) DeleteKatelloProduct(ctx context.Context, id int) error {
 // the supplied ForemanKatelloProduct reference and returns a QueryResponse struct
 // containing query/response metadata and the matching sync plan.
 func (c *Client) QueryKatelloProduct(ctx context.Context, p *ForemanKatelloProduct) (QueryResponse, error) {
-	log.Tracef("foreman/api/product.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/provisioningtemplate.go
+++ b/foreman/api/provisioningtemplate.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -91,7 +92,7 @@ type foremanProvisioningTemplateJSON struct {
 // expects all parameters to be enclosed in double quotes, with the exception
 // of boolean and slice values.
 func (ft ForemanProvisioningTemplate) MarshalJSON() ([]byte, error) {
-	log.Tracef("Provisioning template marshal")
+	utils.TraceFunctionCall()
 
 	// map structure representation of the passed ForemanProvisioningTemplate
 	// for ease of marshalling - essentially convert over to a map then call
@@ -128,6 +129,8 @@ func (ft ForemanProvisioningTemplate) MarshalJSON() ([]byte, error) {
 // Custom JSON unmarshal function. Unmarshal to the unexported JSON struct
 // and then convert over to a ForemanProvisioningTemplate struct.
 func (ft *ForemanProvisioningTemplate) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -188,7 +191,7 @@ func (ft *ForemanProvisioningTemplate) UnmarshalJSON(b []byte) error {
 // reference will have its ID and other API default values set by this
 // function.
 func (c *Client) CreateProvisioningTemplate(ctx context.Context, t *ForemanProvisioningTemplate) (*ForemanProvisioningTemplate, error) {
-	log.Tracef("foreman/api/provisioningtemplate.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", ProvisioningTemplateEndpointPrefix)
 
@@ -224,7 +227,7 @@ func (c *Client) CreateProvisioningTemplate(ctx context.Context, t *ForemanProvi
 // ForemanProvisioningTemplate identified by the supplied ID and returns a
 // ForemanProvisioningTemplate reference.
 func (c *Client) ReadProvisioningTemplate(ctx context.Context, id int) (*ForemanProvisioningTemplate, error) {
-	log.Tracef("foreman/api/provisioningtemplate.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ProvisioningTemplateEndpointPrefix, id)
 
@@ -255,7 +258,7 @@ func (c *Client) ReadProvisioningTemplate(ctx context.Context, id int) (*Foreman
 // ForemanProvisioningTemplate reference is returned with the attributes from
 // the result of the update operation.
 func (c *Client) UpdateProvisioningTemplate(ctx context.Context, t *ForemanProvisioningTemplate) (*ForemanProvisioningTemplate, error) {
-	log.Tracef("foreman/api/provisioningtemplate.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ProvisioningTemplateEndpointPrefix, t.Id)
 	tJSONBytes, jsonEncErr := c.WrapJSONWithTaxonomy("provisioning_template", t)
@@ -289,7 +292,7 @@ func (c *Client) UpdateProvisioningTemplate(ctx context.Context, t *ForemanProvi
 // DeleteProvisioningTemplate deletes the ForemanProvisioningTemplate
 // identified by the supplied ID
 func (c *Client) DeleteProvisioningTemplate(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/provisioningtemplate.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ProvisioningTemplateEndpointPrefix, id)
 
@@ -315,7 +318,7 @@ func (c *Client) DeleteProvisioningTemplate(ctx context.Context, id int) error {
 // returns a QueryResponse struct containing query/response metadata and the
 // matching templates.
 func (c *Client) QueryProvisioningTemplate(ctx context.Context, t *ForemanProvisioningTemplate) (QueryResponse, error) {
-	log.Tracef("foreman/api/provisioningtemplate.go#Query")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/puppetclass.go
+++ b/foreman/api/puppetclass.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 	"strings"
 
@@ -30,7 +31,7 @@ type ForemanPuppetClass struct {
 // ReadPuppetClass reads the attributes of a ForemanPuppetClass identified by
 // the supplied ID and returns a ForemanPuppetClass reference.
 func (c *Client) ReadPuppetClass(ctx context.Context, id int) (*ForemanPuppetClass, error) {
-	log.Tracef("foreman/api/puppetclass.go#Read")
+	utils.TraceFunctionCall()
 
 	req, reqErr := c.NewRequestWithContext(
 		ctx,
@@ -65,7 +66,7 @@ func (c *Client) ReadPuppetClass(ctx context.Context, id int) (*ForemanPuppetCla
 // To work around this the results field is unmarshalled and then remarshalled
 // into an array to normalise it
 func (c *Client) QueryPuppetClass(ctx context.Context, t *ForemanPuppetClass) (QueryResponse, error) {
-	log.Tracef("foreman/api/puppetclass.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponsePuppet{}
 	realQueryResponse := QueryResponse{}

--- a/foreman/api/repository.go
+++ b/foreman/api/repository.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -68,6 +69,8 @@ type ForemanKatelloRepository struct {
 }
 
 func (r *ForemanKatelloRepository) MarshalJSON() ([]byte, error) {
+	utils.TraceFunctionCall()
+
 	m := map[string]interface{}{
 		"id":                   r.Id,
 		"name":                 r.Name,
@@ -124,7 +127,7 @@ func (r *ForemanKatelloRepository) MarshalJSON() ([]byte, error) {
 // ForemanKatelloRepository reference. The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateKatelloRepository(ctx context.Context, p *ForemanKatelloRepository) (*ForemanKatelloRepository, error) {
-	log.Tracef("foreman/api/repository.go#Create")
+	utils.TraceFunctionCall()
 
 	sJSONBytes, jsonEncErr := c.WrapJSON(nil, p)
 	if jsonEncErr != nil {
@@ -157,7 +160,7 @@ func (c *Client) CreateKatelloRepository(ctx context.Context, p *ForemanKatelloR
 // ReadKatelloRepository reads the attributes of a ForemanKatelloRepository identified by the
 // supplied ID and returns a ForemanKatelloRepository reference.
 func (c *Client) ReadKatelloRepository(ctx context.Context, id int) (*ForemanKatelloRepository, error) {
-	log.Tracef("foreman/api/repository.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloRepositoryEndpointPrefix, id)
 
@@ -189,7 +192,7 @@ func (c *Client) ReadKatelloRepository(ctx context.Context, id int) (*ForemanKat
 // ForemanKatelloRepository reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateKatelloRepository(ctx context.Context, p *ForemanKatelloRepository) (*ForemanKatelloRepository, error) {
-	log.Tracef("foreman/api/repository.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloRepositoryEndpointPrefix, p.Id)
 
@@ -223,7 +226,7 @@ func (c *Client) UpdateKatelloRepository(ctx context.Context, p *ForemanKatelloR
 
 // DeleteKatelloRepository deletes the ForemanKatelloRepository identified by the supplied ID
 func (c *Client) DeleteKatelloRepository(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/repository.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("%s/%d", KatelloRepositoryEndpointPrefix, id)
 
@@ -248,7 +251,7 @@ func (c *Client) DeleteKatelloRepository(ctx context.Context, id int) error {
 // the supplied ForemanKatelloRepository reference and returns a QueryResponse struct
 // containing query/response metadata and the matching sync plan.
 func (c *Client) QueryKatelloRepository(ctx context.Context, p *ForemanKatelloRepository) (QueryResponse, error) {
-	log.Tracef("foreman/api/repository.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/setting.go
+++ b/foreman/api/setting.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -57,7 +58,7 @@ type ForemanSetting struct {
 // ReadSetting reads the attributes of a ForemanSetting identified by the supplied
 // ID and returns a ForemanSetting reference.
 func (c *Client) ReadSetting(ctx context.Context, id string) (*ForemanSetting, error) {
-	log.Tracef("foreman/api/setting.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%s", SettingEndpointPrefix, id)
 
@@ -87,7 +88,7 @@ func (c *Client) ReadSetting(ctx context.Context, id string) (*ForemanSetting, e
 // containing query/response metadata and the matching settings.
 // TODO: Copied from QueryDomains.
 func (c *Client) QuerySetting(ctx context.Context, d *ForemanSetting) (QueryResponse, error) {
-	log.Tracef("foreman/api/setting.go#Query")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/smartclassparameter.go
+++ b/foreman/api/smartclassparameter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -36,7 +37,7 @@ type ForemanSmartClassParameter struct {
 // ReadSmartClassParamter reads the attributes of a ForemanSmartClassParameter identified by
 // the supplied ID and returns a ForemanSmartClassParameter reference.
 func (c *Client) ReadSmartClassParameter(ctx context.Context, id int) (*ForemanSmartClassParameter, error) {
-	log.Tracef("foreman/api/smartsclassparameter.go#Read")
+	utils.TraceFunctionCall()
 
 	req, reqErr := c.NewRequestWithContext(
 		ctx,
@@ -67,7 +68,7 @@ func (c *Client) ReadSmartClassParameter(ctx context.Context, id int) (*ForemanS
 // of the supplied ForemanSmartClassParameter reference and returns a QueryResponse
 // struct containing query/response metadata
 func (c *Client) QuerySmartClassParameter(ctx context.Context, t *ForemanSmartClassParameter) (QueryResponse, error) {
-	log.Tracef("foreman/api/smartclassparameter.go#Search")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(SmartClassParameterQueryEndpointPrefix, t.PuppetClassId)
 

--- a/foreman/api/smartproxy.go
+++ b/foreman/api/smartproxy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -45,7 +46,7 @@ type ForemanSmartProxy struct {
 // ForemanSmartProxy reference.  The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateSmartProxy(ctx context.Context, s *ForemanSmartProxy) (*ForemanSmartProxy, error) {
-	log.Tracef("foreman/api/smartproxy.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", SmartProxyEndpointPrefix)
 
@@ -80,7 +81,7 @@ func (c *Client) CreateSmartProxy(ctx context.Context, s *ForemanSmartProxy) (*F
 // ReadSmartProxy reads the attributes of a ForemanSmartProxy identified by the
 // supplied ID and returns a ForemanSmartProxy reference.
 func (c *Client) ReadSmartProxy(ctx context.Context, id int) (*ForemanSmartProxy, error) {
-	log.Tracef("foreman/api/smartproxy.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SmartProxyEndpointPrefix, id)
 
@@ -110,7 +111,7 @@ func (c *Client) ReadSmartProxy(ctx context.Context, id int) (*ForemanSmartProxy
 // ForemanSmartProxy reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateSmartProxy(ctx context.Context, s *ForemanSmartProxy) (*ForemanSmartProxy, error) {
-	log.Tracef("foreman/api/smartproxy.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SmartProxyEndpointPrefix, s.Id)
 
@@ -144,7 +145,7 @@ func (c *Client) UpdateSmartProxy(ctx context.Context, s *ForemanSmartProxy) (*F
 
 // DeleteSmartProxy deletes the ForemanSmartProxy identified by the supplied ID
 func (c *Client) DeleteSmartProxy(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/smartproxy.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SmartProxyEndpointPrefix, id)
 
@@ -169,7 +170,7 @@ func (c *Client) DeleteSmartProxy(ctx context.Context, id int) error {
 // the supplied ForemanSmartProxy reference and returns a QueryResponse struct
 // containing query/response metadata and the matching smart proxy.
 func (c *Client) QuerySmartProxy(ctx context.Context, s *ForemanSmartProxy) (QueryResponse, error) {
-	log.Tracef("foreman/api/smartproxy.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/subnet.go
+++ b/foreman/api/subnet.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -85,7 +86,7 @@ type ForemanSubnet struct {
 // The returned reference will have its ID and other API default values set by
 // this function.
 func (c *Client) CreateSubnet(ctx context.Context, s *ForemanSubnet) (*ForemanSubnet, error) {
-	log.Tracef("foreman/api/subnet.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", SubnetEndpointPrefix)
 
@@ -120,7 +121,7 @@ func (c *Client) CreateSubnet(ctx context.Context, s *ForemanSubnet) (*ForemanSu
 // ReadSubnet reads the attributes of a ForemanSubnet identified by the
 // supplied ID and returns a ForemanSubnet reference.
 func (c *Client) ReadSubnet(ctx context.Context, id int) (*ForemanSubnet, error) {
-	log.Tracef("foreman/api/subnet.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SubnetEndpointPrefix, id)
 
@@ -154,7 +155,7 @@ func (c *Client) ReadSubnet(ctx context.Context, id int) (*ForemanSubnet, error)
 // of the supplied ForemanSubnet will be updated. A new ForemanSubnet reference
 // is returned with the attributes from the result of the update operation.
 func (c *Client) UpdateSubnet(ctx context.Context, s *ForemanSubnet) (*ForemanSubnet, error) {
-	log.Tracef("foreman/api/subnet.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SubnetEndpointPrefix, s.Id)
 
@@ -188,7 +189,7 @@ func (c *Client) UpdateSubnet(ctx context.Context, s *ForemanSubnet) (*ForemanSu
 
 // DeleteSubnet deletes the ForemanSubnet identified by the supplied ID
 func (c *Client) DeleteSubnet(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/subnet.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SubnetEndpointPrefix, id)
 
@@ -213,7 +214,7 @@ func (c *Client) DeleteSubnet(ctx context.Context, id int) error {
 // supplied ForemanSubnet reference and returns a QueryResponse struct
 // containing query/response metadata and the matching subnets
 func (c *Client) QuerySubnet(ctx context.Context, s *ForemanSubnet) (QueryResponse, error) {
-	log.Tracef("foreman/api/subnet.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/sync_plan.go
+++ b/foreman/api/sync_plan.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -48,7 +49,7 @@ type ForemanKatelloSyncPlan struct {
 // ForemanKatelloSyncPlan reference.  The returned reference will have its ID and
 // other API default values set by this function.
 func (c *Client) CreateKatelloSyncPlan(ctx context.Context, sp *ForemanKatelloSyncPlan) (*ForemanKatelloSyncPlan, error) {
-	log.Tracef("foreman/api/sync_plan.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(KatelloSyncPlanEndpointPrefix, c.clientConfig.OrganizationID)
 
@@ -83,7 +84,7 @@ func (c *Client) CreateKatelloSyncPlan(ctx context.Context, sp *ForemanKatelloSy
 // ReadKatelloSyncPlan reads the attributes of a ForemanKatelloSyncPlan identified by the
 // supplied ID and returns a ForemanKatelloSyncPlan reference.
 func (c *Client) ReadKatelloSyncPlan(ctx context.Context, id int) (*ForemanKatelloSyncPlan, error) {
-	log.Tracef("foreman/api/sync_plan.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(KatelloSyncPlanEndpointPrefix, c.clientConfig.OrganizationID)
 	log.Debugf("readKatelloSyncPlan reqEndpoint: [%+v]", reqEndpoint)
@@ -115,7 +116,7 @@ func (c *Client) ReadKatelloSyncPlan(ctx context.Context, id int) (*ForemanKatel
 // ForemanKatelloSyncPlan reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateKatelloSyncPlan(ctx context.Context, sp *ForemanKatelloSyncPlan) (*ForemanKatelloSyncPlan, error) {
-	log.Tracef("foreman/api/sync_plan.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(KatelloSyncPlanEndpointPrefix, c.clientConfig.OrganizationID)
 	reqEndpoint = fmt.Sprintf("%s/%d", reqEndpoint, sp.Id)
@@ -150,7 +151,7 @@ func (c *Client) UpdateKatelloSyncPlan(ctx context.Context, sp *ForemanKatelloSy
 
 // DeleteKatelloSyncPlan deletes the ForemanKatelloSyncPlan identified by the supplied ID
 func (c *Client) DeleteKatelloSyncPlan(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/sync_plan.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(KatelloSyncPlanEndpointPrefix, c.clientConfig.OrganizationID)
 	reqEndpoint = fmt.Sprintf("%s/%d", reqEndpoint, id)
@@ -176,7 +177,7 @@ func (c *Client) DeleteKatelloSyncPlan(ctx context.Context, id int) error {
 // the supplied ForemanKatelloSyncPlan reference and returns a QueryResponse struct
 // containing query/response metadata and the matching sync plan.
 func (c *Client) QueryKatelloSyncPlan(ctx context.Context, sp *ForemanKatelloSyncPlan) (QueryResponse, error) {
-	log.Tracef("foreman/api/sync_plan.go#Search")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(KatelloSyncPlanEndpointPrefix, c.clientConfig.OrganizationID)
 

--- a/foreman/api/templatekind.go
+++ b/foreman/api/templatekind.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -35,7 +36,7 @@ type ForemanTemplateKind struct {
 // ReadTemplateKind reads the attributes of a ForemanTemplateKind identified by
 // the supplied ID and returns a ForemanTemplateKind reference.
 func (c *Client) ReadTemplateKind(ctx context.Context, id int) (*ForemanTemplateKind, error) {
-	log.Tracef("foreman/api/templatekind.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", TemplateKindEndpointPrefix, id)
 
@@ -68,7 +69,7 @@ func (c *Client) ReadTemplateKind(ctx context.Context, id int) (*ForemanTemplate
 // of the supplied ForemanTemplateKind reference and returns a QueryResponse
 // struct containing query/response metadata and the matching template kinds
 func (c *Client) QueryTemplateKind(ctx context.Context, t *ForemanTemplateKind) (QueryResponse, error) {
-	log.Tracef("foreman/api/templatekind.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/user.go
+++ b/foreman/api/user.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -71,7 +72,7 @@ type ForemanUser struct {
 // reference.  The returned reference will have its ID and other API default
 // values set by this function.
 func (c *Client) CreateUser(ctx context.Context, u *ForemanUser) (*ForemanUser, error) {
-	log.Tracef("foreman/api/user.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", UserEndpointPrefix)
 
@@ -106,7 +107,7 @@ func (c *Client) CreateUser(ctx context.Context, u *ForemanUser) (*ForemanUser, 
 // ReadUser reads the attributes of a ForemanUser identified by the
 // supplied ID and returns a ForemanUser reference.
 func (c *Client) ReadUser(ctx context.Context, id int) (*ForemanUser, error) {
-	log.Tracef("foreman/api/user.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", UserEndpointPrefix, id)
 
@@ -136,7 +137,7 @@ func (c *Client) ReadUser(ctx context.Context, id int) (*ForemanUser, error) {
 // ForemanUser reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateUser(ctx context.Context, u *ForemanUser) (*ForemanUser, error) {
-	log.Tracef("foreman/api/user.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", UserEndpointPrefix, u.Id)
 
@@ -170,7 +171,7 @@ func (c *Client) UpdateUser(ctx context.Context, u *ForemanUser) (*ForemanUser, 
 
 // DeleteUser deletes the ForemanUser identified by the supplied ID
 func (c *Client) DeleteUser(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/user.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", UserEndpointPrefix, id)
 
@@ -191,7 +192,7 @@ func (c *Client) DeleteUser(ctx context.Context, id int) error {
 // supplied ForemanUser reference and returns a QueryResponse struct
 // containing query/response metadata and the matching subnets
 func (c *Client) QueryUser(ctx context.Context, s *ForemanUser) (QueryResponse, error) {
-	log.Tracef("foreman/api/user.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/api/usergroup.go
+++ b/foreman/api/usergroup.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
 
 	"github.com/HanseMerkur/terraform-provider-utils/log"
@@ -29,7 +30,7 @@ type ForemanUsergroup struct {
 
 // Implement the Marshaler interface
 func (fh ForemanUsergroup) MarshalJSON() ([]byte, error) {
-	log.Tracef("foreman/api/usergroup.go#MarshalJSON")
+	utils.TraceFunctionCall()
 
 	// NOTE(ALL): omit the "name" property from the JSON marshal since it is a
 	//   computed value
@@ -45,6 +46,8 @@ func (fh ForemanUsergroup) MarshalJSON() ([]byte, error) {
 }
 
 func (fh *ForemanUsergroup) UnmarshalJSON(b []byte) error {
+	utils.TraceFunctionCall()
+
 	var jsonDecErr error
 
 	// Unmarshal the common Foreman object properties
@@ -79,7 +82,7 @@ func (fh *ForemanUsergroup) UnmarshalJSON(b []byte) error {
 // reference.  The returned reference will have its ID and other API default
 // values set by this function.
 func (c *Client) CreateUsergroup(ctx context.Context, h *ForemanUsergroup) (*ForemanUsergroup, error) {
-	log.Tracef("foreman/api/usergroup.go#Create")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s", UsergroupEndpointPrefix)
 
@@ -114,7 +117,7 @@ func (c *Client) CreateUsergroup(ctx context.Context, h *ForemanUsergroup) (*For
 // ReadUsergroup reads the attributes of a ForemanUsergroup identified by the
 // supplied ID and returns a ForemanUsergroup reference.
 func (c *Client) ReadUsergroup(ctx context.Context, id int) (*ForemanUsergroup, error) {
-	log.Tracef("foreman/api/usergroup.go#Read")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", UsergroupEndpointPrefix, id)
 
@@ -144,7 +147,7 @@ func (c *Client) ReadUsergroup(ctx context.Context, id int) (*ForemanUsergroup, 
 // ForemanUsergroup reference is returned with the attributes from the result
 // of the update operation.
 func (c *Client) UpdateUsergroup(ctx context.Context, h *ForemanUsergroup) (*ForemanUsergroup, error) {
-	log.Tracef("foreman/api/usergroup.go#Update")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", UsergroupEndpointPrefix, h.Id)
 
@@ -178,7 +181,7 @@ func (c *Client) UpdateUsergroup(ctx context.Context, h *ForemanUsergroup) (*For
 
 // DeleteUsergroup deletes the ForemanUsergroup identified by the supplied ID
 func (c *Client) DeleteUsergroup(ctx context.Context, id int) error {
-	log.Tracef("foreman/api/usergroup.go#Delete")
+	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", UsergroupEndpointPrefix, id)
 
@@ -203,7 +206,7 @@ func (c *Client) DeleteUsergroup(ctx context.Context, id int) error {
 // supplied ForemanUsergroup reference and returns a QueryResponse struct
 // containing query/response metadata and the matching usergroups.
 func (c *Client) QueryUsergroup(ctx context.Context, u *ForemanUsergroup) (QueryResponse, error) {
-	log.Tracef("foreman/api/usergroup.go#Search")
+	utils.TraceFunctionCall()
 
 	queryResponse := QueryResponse{}
 

--- a/foreman/config.go
+++ b/foreman/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/HanseMerkur/terraform-provider-utils/log"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/terraform-coop/terraform-provider-foreman/foreman/api"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 )
 
 // Config struct defines the necessary information needed to configure the
@@ -34,7 +35,7 @@ type Config struct {
 // client is then authenticated with the credentials supplied to the provider
 // configuration.
 func (c *Config) Client() (*api.Client, diag.Diagnostics) {
-	log.Tracef("config.go#Client")
+	utils.TraceFunctionCall()
 
 	client := api.NewClient(
 		c.Server,

--- a/foreman/provider.go
+++ b/foreman/provider.go
@@ -2,6 +2,7 @@ package foreman
 
 import (
 	"context"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"log"
 	"net/url"
 	"os"
@@ -247,6 +248,7 @@ func Provider() *schema.Provider {
 // configure the provider.  Returns an authenticated REST client for
 // communication with Foreman.
 func providerConfigure(context context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	utils.TraceFunctionCall()
 
 	var ok bool
 

--- a/foreman/resource_foreman_domain.go
+++ b/foreman/resource_foreman_domain.go
@@ -3,6 +3,7 @@ package foreman
 import (
 	"context"
 	"fmt"
+	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"strconv"
 
 	"github.com/HanseMerkur/terraform-provider-utils/autodoc"
@@ -77,7 +78,7 @@ func resourceForemanDomain() *schema.Resource {
 // the resource data.  Missing members will be left to the zero value for that
 // member's type.
 func buildForemanDomain(d *schema.ResourceData) *api.ForemanDomain {
-	log.Tracef("resource_foreman_domain.go#buildForemanDomain")
+	utils.TraceFunctionCall()
 
 	domain := api.ForemanDomain{}
 
@@ -102,6 +103,7 @@ func buildForemanDomain(d *schema.ResourceData) *api.ForemanDomain {
 // attributes of the supplied ForemanDomain reference
 func setResourceDataFromForemanDomain(d *schema.ResourceData, fd *api.ForemanDomain) {
 	log.Tracef("resource_foreman_domain.go#setResourceDataFromForemanDomain")
+	utils.TraceFunctionCall()
 
 	d.SetId(strconv.Itoa(fd.Id))
 	d.Set("name", fd.Name)
@@ -114,7 +116,7 @@ func setResourceDataFromForemanDomain(d *schema.ResourceData, fd *api.ForemanDom
 // -----------------------------------------------------------------------------
 
 func resourceForemanDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Tracef("resource_foreman_domain.go#Create")
+	utils.TraceFunctionCall()
 
 	client := meta.(*api.Client)
 	p := buildForemanDomain(d)
@@ -134,7 +136,7 @@ func resourceForemanDomainCreate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceForemanDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Tracef("resource_foreman_domain.go#Read")
+	utils.TraceFunctionCall()
 
 	client := meta.(*api.Client)
 	domain := buildForemanDomain(d)
@@ -154,7 +156,8 @@ func resourceForemanDomainRead(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceForemanDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Tracef("resource_foreman_domain.go#Update")
+	utils.TraceFunctionCall()
+
 	client := meta.(*api.Client)
 	do := buildForemanDomain(d)
 
@@ -173,7 +176,7 @@ func resourceForemanDomainUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceForemanDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Tracef("resource_foreman_domain.go#Delete")
+	utils.TraceFunctionCall()
 
 	client := meta.(*api.Client)
 	do := buildForemanDomain(d)

--- a/foreman/utils/utils.go
+++ b/foreman/utils/utils.go
@@ -1,9 +1,33 @@
 package utils
 
+import (
+	"github.com/HanseMerkur/terraform-provider-utils/log"
+	"runtime"
+	"strings"
+)
+
 // Provides util functions for the provider package
 
 func TraceFunctionCall() {
-	// Removed in branch feat/job_templates, to be filled in separate branch
+	// Get the program counter and result from the Go stack
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		log.Warningf("Error in TraceFunctionCall runtime.Caller")
+		return
+	}
+
+	// Get details about the caller function (the one that calls utils.TraceFunctionCall)
+	fun := runtime.FuncForPC(pc)
+	funName := fun.Name()
+	funFile, funLine := fun.FileLine(pc)
+
+	// Strip the package prefix
+	const prefix = "github.com/terraform-coop/terraform-provider-foreman/"
+	funName = strings.TrimPrefix(funName, prefix)
+	funFile = strings.TrimPrefix(funFile, prefix)
+
+	log.Tracef("%s (called from %s:%d)",
+		funName, funFile, funLine)
 }
 
 // Like `log.Debugf` but also prints the current file name and line number with the log output


### PR DESCRIPTION
Implements the TraceFunctionCall function in 'utils.go'. 

All 'log.Tracef()' calls are replaced with the new function.

Refs #138
See: https://github.com/terraform-coop/terraform-provider-foreman/pull/138#issuecomment-1860428483