### PR TITLE
Change some resource arguments to required and add autodoc documentation

### DIFF
--- a/foreman/resource_foreman_subnet.go
+++ b/foreman/resource_foreman_subnet.go
@@ -92,7 +92,7 @@ func resourceForemanSubnet() *schema.Resource {
 
 			"ipam": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"DHCP",
 					"Internal DB",
@@ -100,10 +100,13 @@ func resourceForemanSubnet() *schema.Resource {
 					"None",
 					// NOTE(ALL): false - do not ignore case when comparing values
 				}, false),
-				Description: "IP address auto-suggestion for this subnet. Valid " +
-					"values include: `\"DHCP\"`, `\"Internal DB\"`, `\"Random DB\"`,`\"None\"`.",
+				Description: fmt.Sprintf(
+					"IP address auto-suggestion for this subnet. Valid "+
+						"values include: `\"DHCP\"`, `\"Internal DB\"`, `\"Random DB\"`,`\"None\"`."+
+						"%s \"DHCP\"",
+					autodoc.MetaExample,
+				),
 			},
-
 			"from": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -120,14 +123,18 @@ func resourceForemanSubnet() *schema.Resource {
 
 			"boot_mode": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"Static",
 					"DHCP",
 					// NOTE(ALL): false - do not ignore case when comparing values
 				}, false),
-				Description: "Default boot mode for instances assigned to this subnet. " +
-					"Values include: `\"Static\"`, `\"DHCP\"`.",
+				Description: fmt.Sprintf(
+					"Default boot mode for instances assigned to this subnet. "+
+						"Values include: `\"Static\"`, `\"DHCP\"`."+
+						"%s \"DHCP\"",
+					autodoc.MetaExample,
+				),
 			},
 			"network_address": {
 				Type:        schema.TypeString,
@@ -140,9 +147,13 @@ func resourceForemanSubnet() *schema.Resource {
 				Description: "VLAN id that is in use in the subnet",
 			},
 			"mtu": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "MTU value for the subnet",
+				Type:     schema.TypeInt,
+				Required: true,
+				Description: fmt.Sprintf(
+					"MTU value for the subnet. "+
+						"%s \"1500\"",
+					autodoc.MetaExample,
+				),
 			},
 			"template_id": {
 				Type:        schema.TypeInt,
@@ -179,12 +190,16 @@ func resourceForemanSubnet() *schema.Resource {
 			},
 			"network_type": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"IPv4",
 					"IPv6",
 				}, false),
-				Description: "Type or protocol, IPv4 or IPv6, defaults to IPv4.",
+				Description: fmt.Sprintf(
+					"Type or protocol, IPv4 or IPv6. "+
+						"%s \"IPv4\"",
+					autodoc.MetaExample,
+				),
 			},
 		},
 	}


### PR DESCRIPTION
Foreman requires mtu, network type, ipam and boot mode but they was flagged as optional in this module. Changed arguments to required and added autodoc documentation.

cat main.tf
```
terraform {
  required_providers {
    foreman = {
      source  = "terraform-coop/foreman"
      version = "0.6.2"
    }
  }
}

provider "foreman" {
  provider_loglevel = "DEBUG"
  provider_logfile = "terraform-provider-foreman.log"

  client_username = <hidden>
  client_password = <hidden>
  client_tls_insecure = "true"
  location_id = -1
  organization_id = -1

  server_hostname = "192.168.122.244"
  server_protocol = "https"
}

resource "foreman_subnet" "example" {
  mask = "255.255.255.0"
  name = "10.228.247.0 BO1"
  network = "10.228.247.0"
  #network_type = "IPv4"
  #boot_mode = "DHCP"
  #ipam = "DHCP"
  #mtu = 1500
}
```


Terraform apply output :
```
terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # foreman_subnet.example will be created
  + resource "foreman_subnet" "example" {
      + __meta__ = (known after apply)
      + id       = (known after apply)
      + mask     = "255.255.255.0"
      + name     = "10.228.247.0 BO1"
      + network  = "10.228.247.0"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

foreman_subnet.example: Creating...
╷
│ Error: HTTP Error:{
│   endpoint:   [https://192.168.122.244/api/subnets]
│   statusCode: [500]
│   respBody:   [{
│   "error": {"message":"ERF42-0624 [Foreman::Exception]: unknown network_type"}
│ }
│ ]
│ }
│ 
│   with foreman_subnet.example,
│   on main.tf line 26, in resource "foreman_subnet" "example":
│   26: resource "foreman_subnet" "example" {
│ 
╵

```
terraform apply output with added network_type:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # foreman_subnet.example will be created
  + resource "foreman_subnet" "example" {
      + __meta__     = (known after apply)
      + id           = (known after apply)
      + mask         = "255.255.255.0"
      + name         = "10.228.247.0 BO1"
      + network      = "10.228.247.0"
      + network_type = "IPv4"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

foreman_subnet.example: Creating...
╷
│ Error: HTTP Error:{
│   endpoint:   [https://192.168.122.244/api/subnets]
│   statusCode: [422]
│   respBody:   [{
│   "error": {"id":null,"errors":{"boot_mode":["is not included in the list"],"ipam":["not supported by this protocol"],"mtu":["must be greater than or equal to 68"]},"full_messages":["Boot mode is not included in the list","Ipam not supported by this protocol","Mtu must be greater than or equal to 68"]}
│ }
│ ]
│ }
│ 
│   with foreman_subnet.example,
│   on main.tf line 26, in resource "foreman_subnet" "example":
│   26: resource "foreman_subnet" "example" {
│ 
╵
```
