### PR TITLE
fix(repositories): Handle download_concurrency missing API return value

### DIFF
--- a/foreman/api/katello_content_views.go
+++ b/foreman/api/katello_content_views.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/terraform-coop/terraform-provider-foreman/foreman/utils"
 	"net/http"
@@ -322,21 +323,30 @@ func (c *Client) ReadContentViewFilters(ctx context.Context, cvId int) (*[]Conte
 	utils.TraceFunctionCall()
 
 	reqEndpoint := fmt.Sprintf(ContentViewFilters, cvId)
-	var cvf []ContentViewFilter
+	var cvfs []ContentViewFilter
+	var queryResponse QueryResponse
 
 	req, err := c.NewRequestWithContext(ctx, http.MethodGet, reqEndpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.SendAndParse(req, &cvf)
+	err = c.SendAndParse(req, &queryResponse)
 	if err != nil {
 		return nil, err
 	}
 
-	utils.Debugf("read content_view filter: %+v", cvf)
+	for _, item := range queryResponse.Results {
+		cvf, ok := item.(ContentViewFilter)
+		if !ok {
+			return nil, errors.New("failed to cast content view filter from results[]")
+		}
+		cvfs = append(cvfs, cvf)
+	}
 
-	return &cvf, nil
+	utils.Debugf("read content_view filter: %+v", cvfs)
+
+	return &cvfs, nil
 }
 
 func (c *Client) UpdateKatelloContentView(ctx context.Context, cv *ContentView) (*ContentView, error) {

--- a/foreman/api/repository.go
+++ b/foreman/api/repository.go
@@ -69,23 +69,32 @@ type ForemanKatelloRepository struct {
 
 func (r *ForemanKatelloRepository) MarshalJSON() ([]byte, error) {
 	m := map[string]interface{}{
-		"id":                   r.Id,
-		"name":                 r.Name,
-		"description":          r.Description,
-		"label":                r.Label,
-		"product_id":           r.ProductId,
-		"url":                  r.Url,
-		"unprotected":          r.Unprotected,
-		"checksum_type":        r.ChecksumType,
-		"ignore_global_proxy":  r.IgnoreGlobalProxy,
-		"ignorable_content":    r.IgnorableContent,
-		"download_policy":      r.DownloadPolicy,
-		"download_concurrency": r.DownloadConcurrency,
-		"mirroring_policy":     r.MirroringPolicy,
-		"mirror_on_sync":       r.MirrorOnSync, // deprecated
-		"verify_ssl_on_sync":   r.VerifySslOnSync,
-		"upstream_username":    r.UpstreamUsername,
-		"upstream_password":    r.UpstreamPassword,
+		"id":                  r.Id,
+		"name":                r.Name,
+		"description":         r.Description,
+		"label":               r.Label,
+		"product_id":          r.ProductId,
+		"url":                 r.Url,
+		"unprotected":         r.Unprotected,
+		"checksum_type":       r.ChecksumType,
+		"ignore_global_proxy": r.IgnoreGlobalProxy,
+		"ignorable_content":   r.IgnorableContent,
+		"download_policy":     r.DownloadPolicy,
+		"mirroring_policy":    r.MirroringPolicy,
+		"mirror_on_sync":      r.MirrorOnSync, // deprecated
+		"verify_ssl_on_sync":  r.VerifySslOnSync,
+		"upstream_username":   r.UpstreamUsername,
+		"upstream_password":   r.UpstreamPassword,
+	}
+
+	// Creating a repository with download_concurrency > 0 works, but the Katello API
+	// does not return this value. Therefore Terraform stores the resource with
+	// download_concurrency=0 in the state, passing 0 in on resource updates. But
+	// this does not work, since the API expects download_concurrency>0, therefore we
+	// skip this field entirely if we run into this case in the JSON marshalling
+	// step.
+	if r.DownloadConcurrency != 0 {
+		m["download_concurrency"] = r.DownloadConcurrency
 	}
 
 	m["content_type"] = r.ContentType


### PR DESCRIPTION
Commit introduces multiple fixes to handle the missing "download_concurrency" parameter in Katello API responses. The func handleDownloadConcurrencyBetweenTerraformAndKatello basically compares the API response with the state, so if the API did not return the value, but we know the value from the Terraform state, we can override this value in the repository struct.

Also adds validation and a fix for the ContentViewFilter query, which seems to have been missed in previous test runs.

Resolves https://github.com/terraform-coop/terraform-provider-foreman/issues/161