### PR TITLE
fix(host_interface_attributes): Add error handling to if attrs

### DIFF
--- a/foreman/resource_foreman_host_test.go
+++ b/foreman/resource_foreman_host_test.go
@@ -311,7 +311,10 @@ func TestSetResourceDataFromForemanHost_Value(t *testing.T) {
 	actualState := ForemanHostToInstanceState(actualObj)
 	actualResourceData := MockForemanHostResourceData(actualState)
 
-	setResourceDataFromForemanHost(actualResourceData, &expectedObj)
+	err := setResourceDataFromForemanHost(actualResourceData, &expectedObj)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ForemanHostResourceDataCompare(t, actualResourceData, expectedResourceData)
 


### PR DESCRIPTION
Adds error handling to host creation code for the interface attributes, where there may be a field used that has nil instead of string.

Resolves https://github.com/terraform-coop/terraform-provider-foreman/issues/160