### PR TITLE
fix: Update action peaceiris/actions-gh-pages to v4 with github_token

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,8 @@ jobs:
       - run: mkdocs build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        env:
-          PERSONAL_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./html
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./html


### PR DESCRIPTION
Upgrades the Github action `peaceiris/actions-gh-pages` from v3 to v4 in the docs deployment workflow. This allows switching from `personal_token` to `github_token` authentication in the action.

Fixes https://github.com/terraform-coop/terraform-provider-foreman/issues/182