### PR TITLE
Fix host rebuild (#190)

### DIFF
--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -446,7 +446,7 @@ func resourceForemanHost() *schema.Resource {
 			"set_build_flag": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Computed:    true,
 				Description: "Sets the Foreman-internal 'build' flag on this host - even if it is already built completely.",
 			},
 
@@ -1304,6 +1304,11 @@ func resourceForemanHostRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
+	// Ensure the 'set_build_flag' state is set correctly
+	if err := d.Set("set_build_flag", readHost.Build); err != nil {
+		return diag.FromErr(err)
+	}
+
 	if d.Get("retry_count").(int) == 0 {
 		d.Set("retry_count", DEFAULT_RETRY_COUNT)
 	}
@@ -1347,6 +1352,15 @@ func resourceForemanHostUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 	} // end HasChange("interfaces_attributes")
+	if d.HasChange("set_build_flag") {
+		desiredBuildFlag := d.Get("set_build_flag").(bool)
+		log.Debugf("Updating build flag for host: %s, desired: %v", h.Name, desiredBuildFlag)
+		if desiredBuildFlag {
+			h.Build = true
+		} else {
+			h.Build = false
+		}
+	}
 
 	hostRetryCount := d.Get("retry_count").(int)
 
@@ -1369,6 +1383,7 @@ func resourceForemanHostUpdate(ctx context.Context, d *schema.ResourceData, meta
 		d.HasChange("build") ||
 		d.HasChange("puppet_class_ids") ||
 		d.HasChange("config_group_ids") ||
+		d.HasChange("set_build_flag") ||
 		d.Get("managed") == false {
 
 		log.Debugf("host: [%+v]", h)
@@ -1450,8 +1465,14 @@ func flattenComputeAttributes(attrs map[string]interface{}) string {
 }
 
 func resourceForemanHostCustomizeDiffComputeAttributes(ctx context.Context, d *schema.ResourceDiff, i interface{}) error {
-	oldVal, newVal := d.GetChange("compute_attributes")
+	if d.HasChange("set_build_flag") {
+		desiredBuildFlag := d.Get("set_build_flag").(bool)
+		if desiredBuildFlag {
+			d.SetNew("set_build_flag", desiredBuildFlag)
+		}
+	}
 
+	oldVal, newVal := d.GetChange("compute_attributes")
 	oldMap := expandComputeAttributes(oldVal.(string))
 	newMap := expandComputeAttributes(newVal.(string))
 

--- a/foreman/resource_foreman_host_test.go
+++ b/foreman/resource_foreman_host_test.go
@@ -597,3 +597,20 @@ func TestResourceHostStateUpgradeV0(t *testing.T) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
 	}
 }
+
+func TestResourceHostUpdate_SetBuildFlag(t *testing.T) {
+	resourceData := schema.TestResourceDataRaw(t, resourceForemanHost().Schema, map[string]interface{}{})
+	resourceData.SetId("123")
+	resourceData.Set("set_build_flag", true)
+
+	meta := &api.Client{}
+	err := resourceForemanHostUpdate(context.Background(), resourceData, meta)
+
+	if err.HasError() {
+		t.Fatalf("Update returned an error: %v", err)
+	}
+
+	if v, ok := resourceData.Get("set_build_flag").(bool); !ok || !v {
+		t.Errorf("Expected set_build_flag to be true after update, got %v", v)
+	}
+}


### PR DESCRIPTION
`set_build_flag` now sets the build flag for existing hosts (#190 & [#125](https://github.com/terraform-coop/terraform-provider-foreman/discussions/125)). Invokes `resourceForemanHostUpdate` when build flag contradicts desired state. Also `UpdateHost` API call is made based on `set_build_flag` argument. Created test for updating the build flag.

Default behaviour if `set_build_flag` isn't specified is the same as now: new hosts are created with build enabled, and after they're built (and flag is disabled) this provider won't enable it again.